### PR TITLE
Benchmark Netlify cache preservation

### DIFF
--- a/migration/context-signal.md
+++ b/migration/context-signal.md
@@ -245,3 +245,11 @@ Reason:
   left-aligned text, and tiny upper-left `SOLD` badges on each scroller tile.
   Local generate passed and generated HTML checks found the expected styling and
   badge markup with 0 old composite refs.
+- Context update 2026-07-14 MDT: an isolated three-run Netlify benchmark on PR
+  3812 tested removing `rm -rf node_modules/.cache` and
+  `yarn cache clean --all` from `yarn generate`. Control/optimized/warm deploy
+  times were 233/222/261 seconds, so cache preservation did not produce a
+  reliable speedup. All 2,452 HTML files and about 4,900 timestamped Nuxt static
+  payload paths churned on each tiny marker change, which is the stronger
+  bottleneck. Production was unchanged. Full details are in
+  `/Users/x/Documents/Codex Projects/Cloudinary/bedford-cache-preservation-benchmark-2026-07-14.md`.

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
         "start": "nuxt start",
         "update:image-dimensions": "node update-image-width-height.mjs", 
         "validate:cms": "node validate-cms-relations.mjs",
-        "generate": "node validate-cms-relations.mjs && rm -rf node_modules/.cache && rm -rf dist && yarn cache clean --all && nuxt generate --modern && for f in dist/*.htm.html; do mv -- \"$f\" \"${f%.htm.html}.htm\"; done && for f in dist/*.html.html; do mv -- \"$f\" \"${f%.html.html}.html\"; done && for f in dist/ipad/*.html.html; do mv -- \"$f\" \"${f%.html.html}.html\"; done"
+        "generate": "node validate-cms-relations.mjs && rm -rf dist && nuxt generate --modern && for f in dist/*.htm.html; do mv -- \"$f\" \"${f%.htm.html}.htm\"; done && for f in dist/*.html.html; do mv -- \"$f\" \"${f%.html.html}.html\"; done && for f in dist/ipad/*.html.html; do mv -- \"$f\" \"${f%.html.html}.html\"; done"
     },
     "lint-staged": {
         "*.{js,vue}": "eslint --cache",

--- a/pages/artists-bios.vue
+++ b/pages/artists-bios.vue
@@ -26,7 +26,7 @@ export default {
                 {
                     hid: 'cx-cache-benchmark-gallery',
                     name: 'cx-cache-benchmark-gallery',
-                    content: 'cx-cache-optimized-b-20260714-002',
+                    content: 'cx-cache-optimized-c-20260714-003',
                 },
             ],
         }

--- a/pages/artists-bios.vue
+++ b/pages/artists-bios.vue
@@ -20,6 +20,17 @@ export default {
             category: 'All'
         }
     },
+    head() {
+        return {
+            meta: [
+                {
+                    hid: 'cx-cache-benchmark-gallery',
+                    name: 'cx-cache-benchmark-gallery',
+                    content: 'cx-cache-control-a-20260714-001',
+                },
+            ],
+        }
+    },
 }
 </script>
 

--- a/pages/artists-bios.vue
+++ b/pages/artists-bios.vue
@@ -26,7 +26,7 @@ export default {
                 {
                     hid: 'cx-cache-benchmark-gallery',
                     name: 'cx-cache-benchmark-gallery',
-                    content: 'cx-cache-control-a-20260714-001',
+                    content: 'cx-cache-optimized-b-20260714-002',
                 },
             ],
         }

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -1111,6 +1111,13 @@ export default {
     },
     head() {
         return {
+            meta: [
+                {
+                    hid: 'cx-cache-benchmark-home',
+                    name: 'cx-cache-benchmark-home',
+                    content: 'cx-cache-control-a-20260714-001',
+                },
+            ],
             script: [
                 {
                     src: 'https://identity.netlify.com/v1/netlify-identity-widget.js',

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -1115,7 +1115,7 @@ export default {
                 {
                     hid: 'cx-cache-benchmark-home',
                     name: 'cx-cache-benchmark-home',
-                    content: 'cx-cache-control-a-20260714-001',
+                    content: 'cx-cache-optimized-b-20260714-002',
                 },
             ],
             script: [

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -1115,7 +1115,7 @@ export default {
                 {
                     hid: 'cx-cache-benchmark-home',
                     name: 'cx-cache-benchmark-home',
-                    content: 'cx-cache-optimized-b-20260714-002',
+                    content: 'cx-cache-optimized-c-20260714-003',
                 },
             ],
             script: [


### PR DESCRIPTION
Isolated Deploy Preview benchmark only. Run A retains the current cache-clearing build command and adds invisible proof markers to the homepage and gallery page. Runs B and C will preserve caches and update those markers. Do not merge until the measured results are reviewed.