### PR TITLE
Harden Netlify generation and restore George T. Hetzel route

### DIFF
--- a/cms/artists/george_t_hetzel_artist-html.json
+++ b/cms/artists/george_t_hetzel_artist-html.json
@@ -2,7 +2,12 @@
   "hasLandingPage": true,
   "name": "George T. Hetzel",
   "tinyDescription": "American, 1846 - 1912",
+  "body": "Do not confuse “George T.” with his famous uncle, Pittsburgh landscapist and founder of the Scalp Level School, George Hetzel. Hetzel grew up in the Spring Hill section of Pittsburgh; however, little is known of his art education or exhibition history. That he had artistic talent is not disputed; however, it is likely that he was only a part-time artist, as it is known that he served as the Deputy Recorder of Allegheny County. One of his paintings is included in the collection of the Westmoreland Museum of American Art, Greensburg, Pennsylvania.",
   "slug": "george_t_hetzel_artist-html",
+  "alias": "",
+  "metaTitle": "George T. Hetzel Paintings For Sale",
+  "metaDescription": "Explore paintings by American artist George T. Hetzel (1846-1912), including Burnished Forest Stream, at Bedford Fine Art Gallery.",
+  "metaKeywords": "George T. Hetzel, American artist, paintings, artwork, 19th century art",
   "paintings": [
     "george_t_hetzel_burnished_forest_stream-html",
     "george_t_hetzel_for_later-html"

--- a/libs/post.js
+++ b/libs/post.js
@@ -1,6 +1,6 @@
 import removeMd from 'remove-markdown'
 
-export const getPostPreview = (body) => {
+export const getPostPreview = (body = '') => {
     const bodyWithoutMarkdown = removeMd(body)
     const nonMidWordSubstringIndex = bodyWithoutMarkdown.indexOf(' ', 300)
     if (nonMidWordSubstringIndex === -1) {

--- a/libs/testimonials.js
+++ b/libs/testimonials.js
@@ -6,9 +6,14 @@ export const loadLongTestimonials = ($content) => {
     return loadTestimonials({ $content, shortOrLong: 'long' })
 }
 
-function loadTestimonials({ $content, shortOrLong }) {
-    return $content('testimonials')
+async function loadTestimonials({ $content, shortOrLong }) {
+    const testimonialField = `${shortOrLong}Testimonial`
+    const testimonials = await $content('testimonials')
         .only(['name', `${shortOrLong}Testimonial`])
         .sortBy('name', 'asc')
         .fetch()
+
+    return testimonials.sort((a, b) => {
+        return a.name.localeCompare(b.name) || a[testimonialField].localeCompare(b[testimonialField])
+    })
 }

--- a/migration/context-signal.md
+++ b/migration/context-signal.md
@@ -1,6 +1,6 @@
 # Context signal
 
-Last updated: 2026-07-15 00:26 MDT
+Last updated: 2026-07-15 03:15 MDT
 
 Reload context before future Netlify, billing, support, CMS publish, deployment, or Bedford backup work.
 
@@ -84,6 +84,14 @@ Reason:
   checks passed, including the corrected logo, shared header/footer, George T.
   Hetzel page with both painting links, and the public iPad index. Production
   remains unchanged.
+- A follow-up legacy CMS compatibility audit found no changes to the admin CMS,
+  Git Gateway configuration, custom Publish Site UI, S3 upload UI, or either
+  Netlify Function. A historical real CMS painting save passed through the new
+  ignore command as site-affecting and required a build. The Deploy Preview
+  serves the admin assets, contains the Identity and publish-script markers,
+  deploys both Functions, and returns the expected 401 from the publish status
+  Function without authentication. An authenticated publish click was not used
+  because it would start an actual production build.
 - Jerry approved V3 as the visual reference for future rollout work. The first
   rollout stage ports only the shared V3 header and footer into the current
   production codebase on an isolated preview branch. The existing homepage

--- a/migration/context-signal.md
+++ b/migration/context-signal.md
@@ -76,8 +76,10 @@ Reason:
   iPad, George T. Hetzel, sitemap-preservation, and production-isolation checks.
   A preview-only HTTP 500 was traced to the production NextLead API receiving a
   Deploy Preview page-load event; production analytics now initializes only on
-  the canonical Bedford hostname. A live documentation-only build-skip test is
-  the next proof step.
+  the canonical Bedford hostname. A live documentation-only commit was canceled
+  by Netlify's ignore command in about 3.1 seconds without generation or
+  publication. A separate `[skip netlify]` pull-request-title test is in
+  progress; restore the normal PR title after recording its result.
 - Jerry approved V3 as the visual reference for future rollout work. The first
   rollout stage ports only the shared V3 header and footer into the current
   production codebase on an isolated preview branch. The existing homepage

--- a/migration/context-signal.md
+++ b/migration/context-signal.md
@@ -1,6 +1,6 @@
 # Context signal
 
-Last updated: 2026-07-15 00:15 MDT
+Last updated: 2026-07-15 00:26 MDT
 
 Reload context before future Netlify, billing, support, CMS publish, deployment, or Bedford backup work.
 
@@ -78,8 +78,12 @@ Reason:
   Deploy Preview page-load event; production analytics now initializes only on
   the canonical Bedford hostname. A live documentation-only commit was canceled
   by Netlify's ignore command in about 3.1 seconds without generation or
-  publication. A separate `[skip netlify]` pull-request-title test is in
-  progress; restore the normal PR title after recording its result.
+  publication. A separate documentation-only commit pushed while the PR title
+  contained `[skip netlify]` created no Netlify deploy record or GitHub Netlify
+  status; the normal PR title was restored. Final desktop and mobile browser
+  checks passed, including the corrected logo, shared header/footer, George T.
+  Hetzel page with both painting links, and the public iPad index. Production
+  remains unchanged.
 - Jerry approved V3 as the visual reference for future rollout work. The first
   rollout stage ports only the shared V3 header and footer into the current
   production codebase on an isolated preview branch. The existing homepage

--- a/migration/context-signal.md
+++ b/migration/context-signal.md
@@ -1,6 +1,6 @@
 # Context signal
 
-Last updated: 2026-07-14 23:18 MDT
+Last updated: 2026-07-15 00:15 MDT
 
 Reload context before future Netlify, billing, support, CMS publish, deployment, or Bedford backup work.
 
@@ -71,7 +71,13 @@ Reason:
   route payload. The
   same branch repairs the missing `/george_t_hetzel_artist.html` route using the
   existing George T. Hetzel biography and both painting records. Production is
-  unchanged; a Deploy Preview and independent verification are still required.
+  unchanged. Pull request 3813 and its Deploy Preview are active. The Netlify
+  post-deploy plugin and an independent verifier pass the representative site,
+  iPad, George T. Hetzel, sitemap-preservation, and production-isolation checks.
+  A preview-only HTTP 500 was traced to the production NextLead API receiving a
+  Deploy Preview page-load event; production analytics now initializes only on
+  the canonical Bedford hostname. A live documentation-only build-skip test is
+  the next proof step.
 - Jerry approved V3 as the visual reference for future rollout work. The first
   rollout stage ports only the shared V3 header and footer into the current
   production codebase on an isolated preview branch. The existing homepage

--- a/migration/context-signal.md
+++ b/migration/context-signal.md
@@ -65,7 +65,10 @@ Reason:
 - An isolated branch now removes repeat-build churn, preserves Nuxt's webpack
   cache, validates all 2,427 expected generated public files, adds conservative
   documentation-only build skipping, and adds post-deploy smoke verification.
-  Two same-commit local generations produced 7,611 byte-identical files. The
+  Two same-commit local generations produced 7,611 byte-identical files. A
+  three-run stable-path proof showed that changing only the deploy identity
+  changes exactly the homepage and Artists/Bios HTML files, rather than every
+  route payload. The
   same branch repairs the missing `/george_t_hetzel_artist.html` route using the
   existing George T. Hetzel biography and both painting records. Production is
   unchanged; a Deploy Preview and independent verification are still required.

--- a/migration/context-signal.md
+++ b/migration/context-signal.md
@@ -1,6 +1,6 @@
 # Context signal
 
-Last updated: 2026-07-15 03:15 MDT
+Last updated: 2026-07-15 03:27 MDT
 
 Reload context before future Netlify, billing, support, CMS publish, deployment, or Bedford backup work.
 
@@ -92,6 +92,13 @@ Reason:
   deploys both Functions, and returns the expected 401 from the publish status
   Function without authentication. An authenticated publish click was not used
   because it would start an actual production build.
+- Production-state verification on 2026-07-15 confirmed PR 3813 is still open
+  and unmerged. GitHub `main` and Netlify production both remain on `e248614d`,
+  the earlier shared header/footer rollout. Production lacks the new deploy
+  marker and the George T. artist route remains 404. Consequently, the live CMS
+  Publish Site button is still using the old production build setup; PR 3813
+  must be merged and successfully built before the new reliability/efficiency
+  setup becomes live.
 - Jerry approved V3 as the visual reference for future rollout work. The first
   rollout stage ports only the shared V3 header and footer into the current
   production codebase on an isolated preview branch. The existing homepage

--- a/migration/context-signal.md
+++ b/migration/context-signal.md
@@ -1,11 +1,20 @@
 # Context signal
 
-Last updated: 2026-07-14 17:19 MDT
+Last updated: 2026-07-14 23:18 MDT
 
 Reload context before future Netlify, billing, support, CMS publish, deployment, or Bedford backup work.
 
 Recently touched or newly important files:
 
+- `migration/netlify-build-efficiency-and-route-reliability-2026-07-14.md`
+- `netlify.toml`
+- `scripts/netlify-ignore-build.mjs`
+- `scripts/verify-deploy.mjs`
+- `netlify/plugins/post-deploy-smoke/`
+- `modules/cx-stable-content.js`
+- `validate-generated-routes.mjs`
+- `cms/artists/george_t_hetzel_artist-html.json`
+- `pages/artist-bio.vue`
 - `migration/header-footer-v3-rollout-2026-07-14.md`
 - `components/HeaderDefault.vue`
 - `components/FooterDefault.vue`
@@ -53,6 +62,13 @@ Recently touched or newly important files:
 
 Reason:
 
+- An isolated branch now removes repeat-build churn, preserves Nuxt's webpack
+  cache, validates all 2,427 expected generated public files, adds conservative
+  documentation-only build skipping, and adds post-deploy smoke verification.
+  Two same-commit local generations produced 7,611 byte-identical files. The
+  same branch repairs the missing `/george_t_hetzel_artist.html` route using the
+  existing George T. Hetzel biography and both painting records. Production is
+  unchanged; a Deploy Preview and independent verification are still required.
 - Jerry approved V3 as the visual reference for future rollout work. The first
   rollout stage ports only the shared V3 header and footer into the current
   production codebase on an isolated preview branch. The existing homepage

--- a/migration/netlify-build-efficiency-and-route-reliability-2026-07-14.md
+++ b/migration/netlify-build-efficiency-and-route-reliability-2026-07-14.md
@@ -73,8 +73,8 @@ Official references:
 1. Pull request 3813 and its public Deploy Preview are active.
 2. The Netlify post-deploy plugin and a separate local verifier both pass all representative routes, V3 shared header/footer checks, the iPad route, George T. Hetzel routes, sitemap preservation, and production isolation.
 3. A fresh desktop browser load of functional commit `de1b461a` produced no new console error. The previous background HTTP 500 was traced to preview analytics reaching the production NextLead API and is fixed by the canonical-host guard.
-4. A documentation-only follow-up commit is being used as the live ignore-command test.
-5. The `[skip netlify]` pull-request-title behavior remains to be tested, after which the normal title must be restored.
+4. Documentation-only commit `aabcb6f9` was canceled by the ignore command in about 3.1 seconds, before generation or publication. Netlify records this expected cancellation with state `error` and the message `Canceled build due to no content change`.
+5. The pull-request title now temporarily contains `[skip netlify]` for a separate live test. The normal title must be restored immediately after the result is recorded.
 6. Do not merge or deploy to production without explicit user approval.
 
 ## Deploy Preview 3813 measurements

--- a/migration/netlify-build-efficiency-and-route-reliability-2026-07-14.md
+++ b/migration/netlify-build-efficiency-and-route-reliability-2026-07-14.md
@@ -111,3 +111,14 @@ Change pushed
 ```
 
 The important distinction is that deterministic output and stable route-state paths make deploys auditable and reduce needless upload, but they cannot make Nuxt 2 avoid rendering 2,427 routes. The only measured way to remove that dominant cost is to avoid starting the build when the source change cannot affect the site. Site-affecting changes still receive the full safety checks.
+
+## Legacy CMS and Publish Site compatibility audit
+
+- The branch does not modify `static/admin/index.html`, `static/admin/config.yml`, `static/admin/bedford-publish-site.js`, `static/admin/bedford-s3-media-library.js`, `netlify/functions/publish-site.js`, or `netlify/functions/s3-upload.js`.
+- The CMS still uses Git Gateway on `main` and adds `[skip netlify]` to ordinary create, update, delete, and media commits.
+- The custom Publish Site Function still authenticates the Netlify Identity user and POSTs to the existing `BEDFORD_NETLIFY_BUILD_HOOK_URL`.
+- A historical real CMS painting-save comparison was passed through `scripts/netlify-ignore-build.mjs`. The changed `cms/paintings/...json` file produced exit 1, meaning a build is required. The ignore rule skips only `migration/` notes and root AGENTS/README Markdown.
+- The verified Deploy Preview serves `/admin/`, `/admin/config.yml`, and `/admin/bedford-publish-site.js` with HTTP 200. The admin page contains both the Netlify Identity widget and custom Publish Site script.
+- The preview deploy includes the two Netlify Functions. An unauthenticated status request to `/.netlify/functions/publish-site` returned the expected HTTP 401 JSON response, proving routing and the authentication guard remain active.
+- The post-deploy smoke plugin passed on the preview. On production it skips preview-versus-production comparisons but still validates the representative public routes, admin Identity marker, shared header/footer, deploy stamp, iPad section, and George T. Hetzel pages.
+- An authenticated click was not performed because that would intentionally start a real production build. The unchanged UI/Function code, deployed Function guard, real CMS-change simulation, and successful full Deploy Preview together provide strong non-destructive compatibility evidence.

--- a/migration/netlify-build-efficiency-and-route-reliability-2026-07-14.md
+++ b/migration/netlify-build-efficiency-and-route-reliability-2026-07-14.md
@@ -16,7 +16,7 @@ Production also returned HTTP 404 for `/george_t_hetzel_artist.html`, although b
 ## Implemented changes
 
 1. `package.json` no longer deletes `node_modules/.cache` or runs `yarn cache clean --all` before every generation. Nuxt can now reuse its webpack snapshot. Generation uses `--fail-on-error` and runs CMS plus output-route validation.
-2. `nuxt.config.js` gives full-static assets a commit-derived version instead of Nuxt's current-time default. Sitemap `lastmod` no longer uses the build time.
+2. `nuxt.config.js` gives full-static route state a stable `cx-v1` directory instead of Nuxt's current-time default. The site revalidates `/_nuxt/static/*` in visitors' browsers while retaining long immutable caching for content-hashed webpack chunks. Netlify atomically invalidates edge assets per deploy. Sitemap `lastmod` no longer uses the build time.
 3. `modules/cx-stable-content.js` compensates for Nuxt Content 1.9's concurrent, timestamped database insertion. Files are parsed in parallel, inserted in stable path order, and volatile Loki creation timestamps are normalized.
 4. Testimonial records now use testimonial text as a stable secondary sort key when customer names tie.
 5. The generated manifest route array is sorted through Nuxt's supported `generate:manifest` hook.
@@ -29,6 +29,7 @@ Production also returned HTTP 404 for `/george_t_hetzel_artist.html`, although b
 12. The iPad index route now generates real content at `/ipad` instead of a generated 404 document.
 13. George T. Hetzel's artist record now contains the existing biographical text and metadata. The artist template falls back across available painting image fields so both of his paintings render. `/george_t_hetzel_artist.html` now generates successfully.
 14. The deploy verifier permits removal of four generic template paths only after confirming each remains a production HTTP 404. This cleans dead sitemap entries without weakening preservation checks for real public routes.
+15. `scripts/stamp-deploy-ref.mjs` adds the invisible commit marker only to the homepage and Artists/Bios output after generation. This independently proves the new deploy on two pages without forcing every page and payload to change.
 
 ## Local proof
 
@@ -36,6 +37,8 @@ Production also returned HTTP 404 for `/george_t_hetzel_artist.html`, although b
 - Same-commit repeat: webpack reported `Skipping webpack build as no changes detected` and completed in 54.31 seconds.
 - Two repeat outputs contained 7,611 files each and were byte-for-byte identical.
 - The final lint-only configuration adjustment produced output identical to the deterministic baseline.
+- Stable-path verification passed across three runs: a same-ref repeat was byte-identical, while changing only the deploy ref changed exactly `index.html` and `Artists--Bios.html` out of 7,611 files.
+- The stable-path same-ref repeat completed in 47.72 seconds with webpack reuse.
 - Lint error gate passed for all new JavaScript and deployment scripts.
 - Current production comparison:
   - `/george_t_hetzel_artist.html`: HTTP 404.
@@ -55,6 +58,7 @@ Official references:
 - https://docs.netlify.com/build/configure-builds/ignore-builds/
 - https://docs.netlify.com/extend/develop-and-share/develop-build-plugins/
 - https://docs.netlify.com/build/configure-builds/environment-variables/
+- https://docs.netlify.com/build/caching/caching-overview/
 
 ## Remaining preview proof
 
@@ -64,3 +68,9 @@ Official references:
 4. Confirm a documentation-only follow-up commit is skipped by the ignore command.
 5. Confirm a `[skip netlify]` pull-request title prevents an intentionally unnecessary preview, then restore the title.
 6. Do not merge or deploy to production without explicit user approval.
+
+## Deploy Preview 3813 measurements
+
+- First preview revision, before the stable route-state path: 267 seconds and 7,454 uploaded files. The post-deploy plugin correctly reported the four dead production sitemap entries.
+- Second preview revision, with the narrowed sitemap verification but still before the stable path: 251 seconds and 4,909 uploaded files. Post-deploy plugin state: `success`.
+- The next revision introduces the stable route-state path and targeted two-page deploy stamp. One initial path transition is expected; the following tiny proof commit is the meaningful upload-reduction measurement.

--- a/migration/netlify-build-efficiency-and-route-reliability-2026-07-14.md
+++ b/migration/netlify-build-efficiency-and-route-reliability-2026-07-14.md
@@ -74,7 +74,7 @@ Official references:
 2. The Netlify post-deploy plugin and a separate local verifier both pass all representative routes, V3 shared header/footer checks, the iPad route, George T. Hetzel routes, sitemap preservation, and production isolation.
 3. A fresh desktop browser load of functional commit `de1b461a` produced no new console error. The previous background HTTP 500 was traced to preview analytics reaching the production NextLead API and is fixed by the canonical-host guard.
 4. Documentation-only commit `aabcb6f9` was canceled by the ignore command in about 3.1 seconds, before generation or publication. Netlify records this expected cancellation with state `error` and the message `Canceled build due to no content change`.
-5. The pull-request title now temporarily contains `[skip netlify]` for a separate live test. The normal title must be restored immediately after the result is recorded.
+5. Documentation-only commit `6500c122` was pushed while the pull-request title temporarily contained `[skip netlify]`. After more than 35 seconds, Netlify had created no deploy record and GitHub had received no Netlify status. The normal pull-request title was then restored.
 6. Do not merge or deploy to production without explicit user approval.
 
 ## Deploy Preview 3813 measurements
@@ -86,3 +86,28 @@ Official references:
 - Analytics-guard functional revision: 258 seconds and 7,436 uploaded files. A shared client-bundle change necessarily changed route HTML and hashed assets, but all verification passed and the preview-only API error stopped recurring.
 
 The two-file proof shows that upload churn is solved, but its 251-second duration also shows that upload was not the primary bottleneck. Full generation of 2,427 content routes, plus Netlify setup/plugin/function overhead, remains the dominant cost. Documentation-only build cancellation is therefore the high-value fast path.
+
+## Final browser verification
+
+- Desktop at 1280 x 900: no horizontal overflow, corrected 250 x 252 source logo, shared header and footer present, public Identity absent, and exact functional deploy ref present.
+- Mobile at 390 x 844: no horizontal overflow, corrected source logo dimensions, shared header and footer present, navigation rendered, and public Identity absent.
+- George T. Hetzel artist page: title and biography rendered, with links to both `george_t_hetzel_burnished_forest_stream.html` and `george_t_hetzel_for_later.html`.
+- iPad index: HTTP 200 and 186 visible iPad painting links in the mobile browser pass.
+- The Deploy Preview remains on verified functional commit `de1b461a`; later documentation-only commits intentionally did not publish a new preview.
+
+## Efficiency result
+
+```text
+Change pushed
+|
++-- Site-affecting file
+|   `-- Full Nuxt generation + validation + deploy smoke (~251-267 seconds)
+|
++-- Documentation only
+|   `-- Ignore command cancels before generation (~3.1 seconds)
+|
+`-- Preview intentionally unnecessary
+    `-- [skip netlify] in PR title creates no deploy attempt
+```
+
+The important distinction is that deterministic output and stable route-state paths make deploys auditable and reduce needless upload, but they cannot make Nuxt 2 avoid rendering 2,427 routes. The only measured way to remove that dominant cost is to avoid starting the build when the source change cannot affect the site. Site-affecting changes still receive the full safety checks.

--- a/migration/netlify-build-efficiency-and-route-reliability-2026-07-14.md
+++ b/migration/netlify-build-efficiency-and-route-reliability-2026-07-14.md
@@ -3,7 +3,9 @@
 ## Status
 
 - Work is isolated on `cx/netlify-efficiency-and-route-fixes-2026-07-14`.
-- Functional commit: `f089555f`.
+- Pull request: https://github.com/nww-static-sites/bedfordfineartgallery.com/pull/3813
+- Deploy Preview: https://deploy-preview-3813--stupefied-ramanujan-ca1b24.netlify.app/
+- Latest verified functional commit: `de1b461a`.
 - Production has not been changed by this work.
 - The earlier cache benchmark PR 3812 remains separate and must not be merged.
 
@@ -30,6 +32,7 @@ Production also returned HTTP 404 for `/george_t_hetzel_artist.html`, although b
 13. George T. Hetzel's artist record now contains the existing biographical text and metadata. The artist template falls back across available painting image fields so both of his paintings render. `/george_t_hetzel_artist.html` now generates successfully.
 14. The deploy verifier permits removal of four generic template paths only after confirming each remains a production HTTP 404. This cleans dead sitemap entries without weakening preservation checks for real public routes.
 15. `scripts/stamp-deploy-ref.mjs` adds the invisible commit marker only to the homepage and Artists/Bios output after generation. This independently proves the new deploy on two pages without forcing every page and payload to change.
+16. Production NextLead analytics now initializes only on the canonical Bedford hostname. Deploy Previews no longer send preview page-load events to the production NextLead API, eliminating the preview-only HTTP 500 while preserving local-development and production behavior.
 
 ## Local proof
 
@@ -44,6 +47,11 @@ Production also returned HTTP 404 for `/george_t_hetzel_artist.html`, although b
   - `/george_t_hetzel_artist.html`: HTTP 404.
   - `/george_t_hetzel_burnished_forest_stream.html`: HTTP 200.
   - Local generated artist route: biography plus both linked paintings present.
+- Deploy Preview comparison:
+  - `/george_t_hetzel_artist.html`: HTTP 200 with George T. Hetzel biography.
+  - `/george_t_hetzel_burnished_forest_stream.html`: HTTP 200.
+  - `/george_t_hetzel_for_later.html`: HTTP 200.
+  - `/ipad/`: HTTP 200.
 
 ## Netlify behavior researched
 
@@ -60,17 +68,21 @@ Official references:
 - https://docs.netlify.com/build/configure-builds/environment-variables/
 - https://docs.netlify.com/build/caching/caching-overview/
 
-## Remaining preview proof
+## Preview proof status
 
-1. Push the isolated branch and create a pull request.
-2. Verify the resulting Deploy Preview independently with the smoke script and browser checks.
-3. Confirm production does not contain the preview commit.
-4. Confirm a documentation-only follow-up commit is skipped by the ignore command.
-5. Confirm a `[skip netlify]` pull-request title prevents an intentionally unnecessary preview, then restore the title.
+1. Pull request 3813 and its public Deploy Preview are active.
+2. The Netlify post-deploy plugin and a separate local verifier both pass all representative routes, V3 shared header/footer checks, the iPad route, George T. Hetzel routes, sitemap preservation, and production isolation.
+3. A fresh desktop browser load of functional commit `de1b461a` produced no new console error. The previous background HTTP 500 was traced to preview analytics reaching the production NextLead API and is fixed by the canonical-host guard.
+4. A documentation-only follow-up commit is being used as the live ignore-command test.
+5. The `[skip netlify]` pull-request-title behavior remains to be tested, after which the normal title must be restored.
 6. Do not merge or deploy to production without explicit user approval.
 
 ## Deploy Preview 3813 measurements
 
 - First preview revision, before the stable route-state path: 267 seconds and 7,454 uploaded files. The post-deploy plugin correctly reported the four dead production sitemap entries.
 - Second preview revision, with the narrowed sitemap verification but still before the stable path: 251 seconds and 4,909 uploaded files. Post-deploy plugin state: `success`.
-- The next revision introduces the stable route-state path and targeted two-page deploy stamp. One initial path transition is expected; the following tiny proof commit is the meaningful upload-reduction measurement.
+- Stable-path transition revision: 254 seconds and 7,329 uploaded files. This one-time churn was expected because every route moved from a commit-specific state directory to `/_nuxt/static/cx-v1`.
+- Minimal source-only proof revision: 251 seconds and exactly 2 uploaded files, `index.html` and `Artists--Bios.html`. The exact commit marker appeared on both pages and nowhere else.
+- Analytics-guard functional revision: 258 seconds and 7,436 uploaded files. A shared client-bundle change necessarily changed route HTML and hashed assets, but all verification passed and the preview-only API error stopped recurring.
+
+The two-file proof shows that upload churn is solved, but its 251-second duration also shows that upload was not the primary bottleneck. Full generation of 2,427 content routes, plus Netlify setup/plugin/function overhead, remains the dominant cost. Documentation-only build cancellation is therefore the high-value fast path.

--- a/migration/netlify-build-efficiency-and-route-reliability-2026-07-14.md
+++ b/migration/netlify-build-efficiency-and-route-reliability-2026-07-14.md
@@ -28,6 +28,7 @@ Production also returned HTTP 404 for `/george_t_hetzel_artist.html`, although b
 11. Generic internal dynamic template routes are removed before concrete CMS routes are registered. This eliminates five meaningless failing generator paths while preserving every real CMS route.
 12. The iPad index route now generates real content at `/ipad` instead of a generated 404 document.
 13. George T. Hetzel's artist record now contains the existing biographical text and metadata. The artist template falls back across available painting image fields so both of his paintings render. `/george_t_hetzel_artist.html` now generates successfully.
+14. The deploy verifier permits removal of four generic template paths only after confirming each remains a production HTTP 404. This cleans dead sitemap entries without weakening preservation checks for real public routes.
 
 ## Local proof
 

--- a/migration/netlify-build-efficiency-and-route-reliability-2026-07-14.md
+++ b/migration/netlify-build-efficiency-and-route-reliability-2026-07-14.md
@@ -1,0 +1,65 @@
+# Netlify build efficiency and route reliability - 2026-07-14
+
+## Status
+
+- Work is isolated on `cx/netlify-efficiency-and-route-fixes-2026-07-14`.
+- Functional commit: `f089555f`.
+- Production has not been changed by this work.
+- The earlier cache benchmark PR 3812 remains separate and must not be merged.
+
+## Why this work was needed
+
+Four controlled Netlify benchmark builds took 222-261 seconds. Clearing caches did not produce a repeatable improvement. More importantly, repeat builds changed almost every generated HTML and payload file even when the source commit was unchanged. The churn caused needless upload work and made deployment identity harder to audit.
+
+Production also returned HTTP 404 for `/george_t_hetzel_artist.html`, although both George T. Hetzel painting records existed.
+
+## Implemented changes
+
+1. `package.json` no longer deletes `node_modules/.cache` or runs `yarn cache clean --all` before every generation. Nuxt can now reuse its webpack snapshot. Generation uses `--fail-on-error` and runs CMS plus output-route validation.
+2. `nuxt.config.js` gives full-static assets a commit-derived version instead of Nuxt's current-time default. Sitemap `lastmod` no longer uses the build time.
+3. `modules/cx-stable-content.js` compensates for Nuxt Content 1.9's concurrent, timestamped database insertion. Files are parsed in parallel, inserted in stable path order, and volatile Loki creation timestamps are normalized.
+4. Testimonial records now use testimonial text as a stable secondary sort key when customer names tie.
+5. The generated manifest route array is sorted through Nuxt's supported `generate:manifest` hook.
+6. Stale `.nuxt/dist/client/content` database assets are removed before generation without deleting the reusable webpack cache.
+7. `validate-generated-routes.mjs` requires 2,427 expected public files: 876 standard painting pages, 876 iPad painting pages, 403 artist pages, 153 article pages, 106 Art Lovers' Niche pages, and representative static routes.
+8. `netlify.toml` uses `scripts/netlify-ignore-build.mjs` to skip only documentation-only changes under `migration/` or root AGENTS/README Markdown. Missing/equal refs, failed comparisons, empty comparisons, and all site-affecting changes build conservatively.
+9. A local Netlify build plugin runs `scripts/verify-deploy.mjs` after a successful deploy. It verifies representative public routes, V3 shared header/footer markers, deploy commit identity, admin-only Identity loading, sitemap route preservation, production isolation, iPad output, and George T. Hetzel routes.
+10. The public Identity widget was removed from homepage variants; it remains on `/admin/` where it belongs. A missing article body no longer crashes preview generation.
+11. Generic internal dynamic template routes are removed before concrete CMS routes are registered. This eliminates five meaningless failing generator paths while preserving every real CMS route.
+12. The iPad index route now generates real content at `/ipad` instead of a generated 404 document.
+13. George T. Hetzel's artist record now contains the existing biographical text and metadata. The artist template falls back across available painting image fields so both of his paintings render. `/george_t_hetzel_artist.html` now generates successfully.
+
+## Local proof
+
+- Strict full generation: passed all 2,427 expected routes in 58.00 seconds.
+- Same-commit repeat: webpack reported `Skipping webpack build as no changes detected` and completed in 54.31 seconds.
+- Two repeat outputs contained 7,611 files each and were byte-for-byte identical.
+- The final lint-only configuration adjustment produced output identical to the deterministic baseline.
+- Lint error gate passed for all new JavaScript and deployment scripts.
+- Current production comparison:
+  - `/george_t_hetzel_artist.html`: HTTP 404.
+  - `/george_t_hetzel_burnished_forest_stream.html`: HTTP 200.
+  - Local generated artist route: biography plus both linked paintings present.
+
+## Netlify behavior researched
+
+- Build ignore commands use exit 0 to cancel and exit 1 to continue a build.
+- `CACHED_COMMIT_REF` can equal `COMMIT_REF` when no prior cache is available, so the ignore script deliberately builds in that case.
+- Local build plugins can be registered with `package = "./path"` and can run an `onSuccess` post-deploy verification.
+- The post-deploy plugin reports a smoke failure with `failPlugin`; it does not roll back or alter production.
+- Deploy Preview creation can additionally be suppressed with `[skip netlify]` or `[skip ci]` in the pull-request title when a preview is intentionally unnecessary.
+
+Official references:
+
+- https://docs.netlify.com/build/configure-builds/ignore-builds/
+- https://docs.netlify.com/extend/develop-and-share/develop-build-plugins/
+- https://docs.netlify.com/build/configure-builds/environment-variables/
+
+## Remaining preview proof
+
+1. Push the isolated branch and create a pull request.
+2. Verify the resulting Deploy Preview independently with the smoke script and browser checks.
+3. Confirm production does not contain the preview commit.
+4. Confirm a documentation-only follow-up commit is skipped by the ignore command.
+5. Confirm a `[skip netlify]` pull-request title prevents an intentionally unnecessary preview, then restore the title.
+6. Do not merge or deploy to production without explicit user approval.

--- a/migration/netlify-build-efficiency-and-route-reliability-2026-07-14.md
+++ b/migration/netlify-build-efficiency-and-route-reliability-2026-07-14.md
@@ -122,3 +122,12 @@ The important distinction is that deterministic output and stable route-state pa
 - The preview deploy includes the two Netlify Functions. An unauthenticated status request to `/.netlify/functions/publish-site` returned the expected HTTP 401 JSON response, proving routing and the authentication guard remain active.
 - The post-deploy smoke plugin passed on the preview. On production it skips preview-versus-production comparisons but still validates the representative public routes, admin Identity marker, shared header/footer, deploy stamp, iPad section, and George T. Hetzel pages.
 - An authenticated click was not performed because that would intentionally start a real production build. The unchanged UI/Function code, deployed Function guard, real CMS-change simulation, and successful full Deploy Preview together provide strong non-destructive compatibility evidence.
+
+## Production rollout state - 2026-07-15
+
+- Pull request 3813 remains open and unmerged at head `d10f3dd7`.
+- GitHub `main` remains at `e248614d`, the approved V3 shared header/footer rollout.
+- Netlify production deploy `6a56c57e015b7800080a3850` serves `e248614d`; it was published on 2026-07-14 and took 260 seconds.
+- The production homepage does not contain the new `cx-deploy-ref` marker, and production still returns HTTP 404 for `/george_t_hetzel_artist.html`.
+- Therefore the deterministic generation, cache preservation, documentation-only ignore rule, strict route validation, post-deploy smoke plugin, NextLead preview guard, and George T. route repair are Deploy Preview-only. The live CMS Publish Site button still invokes the pre-3813 production build setup.
+- Merging PR 3813 into `main` and allowing its production build to pass is required before any CMS publish uses the new setup.

--- a/modules/cx-stable-content.js
+++ b/modules/cx-stable-content.js
@@ -1,0 +1,55 @@
+const { join } = require('path')
+const fs = require('graceful-fs').promises
+
+async function collectContentPaths(database, dir, files) {
+    let entries = []
+
+    try {
+        entries = (await fs.readdir(dir)).sort((a, b) => a.localeCompare(b))
+    } catch (error) {
+        return
+    }
+
+    for (const entry of entries) {
+        if (entry.includes('node_modules') || /(^|\/)\.[^/.]/.test(entry)) {
+            continue
+        }
+
+        const path = join(dir, entry)
+        const stats = await fs.stat(path)
+
+        if (stats.isDirectory()) {
+            database.dirs.push(database.normalizePath(path))
+            await collectContentPaths(database, path, files)
+        } else if (stats.isFile()) {
+            files.push(path)
+        }
+    }
+}
+
+module.exports = function stabilizeContentDatabase() {
+    const Database = require('@nuxt/content/lib/database')
+
+    Database.prototype.init = async function initStableContentDatabase() {
+        this.dirs = ['/']
+        this.items.clear()
+
+        const files = []
+        await collectContentPaths(this, this.dir, files)
+
+        const parsedItems = await Promise.all(files.map((file) => this.parseFile(file)))
+
+        for (const item of parsedItems) {
+            if (!item) {
+                continue
+            }
+
+            await this.callHook('file:beforeInsert', item)
+            this.items.insert(item)
+
+            if (item.meta) {
+                item.meta.created = 0
+            }
+        }
+    }
+}

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,0 +1,5 @@
+[build]
+  ignore = "node ./scripts/netlify-ignore-build.mjs"
+
+[[plugins]]
+  package = "./netlify/plugins/post-deploy-smoke"

--- a/netlify/plugins/post-deploy-smoke/index.js
+++ b/netlify/plugins/post-deploy-smoke/index.js
@@ -1,0 +1,50 @@
+const { spawn } = require('node:child_process')
+
+function runSmokeVerification() {
+    return new Promise((resolve) => {
+        const child = spawn(process.execPath, ['./scripts/verify-deploy.mjs'], {
+            cwd: process.cwd(),
+            env: process.env,
+            stdio: ['ignore', 'pipe', 'pipe'],
+        })
+        let output = ''
+
+        child.stdout.on('data', (chunk) => {
+            const text = chunk.toString()
+            output += text
+            process.stdout.write(text)
+        })
+        child.stderr.on('data', (chunk) => {
+            const text = chunk.toString()
+            output += text
+            process.stderr.write(text)
+        })
+        child.on('close', (code) => resolve({ code, output }))
+    })
+}
+
+module.exports = {
+    onSuccess: async ({ utils }) => {
+        if (!process.env.DEPLOY_PRIME_URL) {
+            utils.status.show({
+                title: 'Deploy smoke verification',
+                summary: 'Skipped because DEPLOY_PRIME_URL is unavailable.',
+            })
+            return
+        }
+
+        const result = await runSmokeVerification()
+
+        if (result.code !== 0) {
+            utils.build.failPlugin('The deployed site failed Bedford smoke verification.', {
+                error: new Error(result.output.trim()),
+            })
+            return
+        }
+
+        utils.status.show({
+            title: 'Deploy smoke verification',
+            summary: 'Representative public routes, shared chrome, route preservation, and deploy identity passed.',
+        })
+    },
+}

--- a/netlify/plugins/post-deploy-smoke/manifest.yml
+++ b/netlify/plugins/post-deploy-smoke/manifest.yml
@@ -1,0 +1,1 @@
+name: bedford-post-deploy-smoke

--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -1,11 +1,4 @@
-const buildEnvironment = Reflect.get(process, 'env')
-
-function readBuildEnvironment(name, fallback = '') {
-    return buildEnvironment[name] || fallback
-}
-
-const deployRef = readBuildEnvironment('COMMIT_REF', 'local')
-const staticAssetsVersion = deployRef.slice(0, 12)
+const staticAssetsVersion = 'cx-v1'
 
 export default {
     // Target: https://go.nuxtjs.dev/config-target
@@ -22,7 +15,6 @@ export default {
             { name: 'viewport', content: 'width=device-width, initial-scale=1' },
             { hid: 'description', name: 'description', content: 'Historic gallery of 19th century paintings for sale, featuring the 19th century art of European, British and American 19th century artists. Many 1800s paintings including 19th century oil paintings by some of the most renowned 19th century painters.' },
             { name: 'format-detection', content: 'telephone=no' },
-            { hid: 'cx-deploy-ref', name: 'cx-deploy-ref', content: deployRef },
         ],
         link: [{ rel: 'icon', type: 'image/x-icon', href: '/favicon.ico' }],
         script: [

--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -1,3 +1,12 @@
+const buildEnvironment = Reflect.get(process, 'env')
+
+function readBuildEnvironment(name, fallback = '') {
+    return buildEnvironment[name] || fallback
+}
+
+const deployRef = readBuildEnvironment('COMMIT_REF', 'local')
+const staticAssetsVersion = deployRef.slice(0, 12)
+
 export default {
     // Target: https://go.nuxtjs.dev/config-target
     target: 'static',
@@ -13,6 +22,7 @@ export default {
             { name: 'viewport', content: 'width=device-width, initial-scale=1' },
             { hid: 'description', name: 'description', content: 'Historic gallery of 19th century paintings for sale, featuring the 19th century art of European, British and American 19th century artists. Many 1800s paintings including 19th century oil paintings by some of the most renowned 19th century painters.' },
             { name: 'format-detection', content: 'telephone=no' },
+            { hid: 'cx-deploy-ref', name: 'cx-deploy-ref', content: deployRef },
         ],
         link: [{ rel: 'icon', type: 'image/x-icon', href: '/favicon.ico' }],
         script: [
@@ -54,6 +64,7 @@ export default {
         '@nuxtjs/markdownit',
         // https://go.nuxtjs.dev/axios
         '@nuxtjs/axios',
+        '~/modules/cx-stable-content',
         '@nuxt/content',
         'nuxt-interpolation',
         '@nuxtjs/sitemap',
@@ -79,6 +90,19 @@ export default {
         trailingSlash: false,
         async extendRoutes(routes, resolve) {
             const { $content } = require('@nuxt/content')
+            const dynamicTemplateRouteNames = new Set([
+                'art-lovers-niche-article',
+                'artist-bio',
+                'highlight',
+                'painting',
+                'ipad-painting',
+            ])
+
+            for (let index = routes.length - 1; index >= 0; index--) {
+                if (dynamicTemplateRouteNames.has(routes[index].name)) {
+                    routes.splice(index, 1)
+                }
+            }
 
             const paintings = await $content('paintings').only(['slug']).fetch()
             paintings.forEach(function(painting) {
@@ -148,11 +172,21 @@ export default {
         ],
         defaults: {
             changefreq: 'weekly',
-            lastmod: new Date(),
+        },
+    },
+    hooks: {
+        'generate:manifest'(manifest) {
+            manifest.routes.sort((a, b) => a.localeCompare(b))
         },
     },
     generate: {
         subFolders: false,
         crawler: true,
+        cache: {
+            ignore: ['migration/**'],
+        },
+        staticAssets: {
+            version: staticAssetsVersion,
+        },
     },
 }

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
         "start": "nuxt start",
         "update:image-dimensions": "node update-image-width-height.mjs", 
         "validate:cms": "node validate-cms-relations.mjs",
-        "generate": "node validate-cms-relations.mjs && rm -rf dist .nuxt/dist/client/content && nuxt generate --modern --fail-on-error && for f in dist/*.htm.html; do mv -- \"$f\" \"${f%.htm.html}.htm\"; done && for f in dist/*.html.html; do mv -- \"$f\" \"${f%.html.html}.html\"; done && for f in dist/ipad/*.html.html; do mv -- \"$f\" \"${f%.html.html}.html\"; done && node validate-generated-routes.mjs",
+        "generate": "node validate-cms-relations.mjs && rm -rf dist .nuxt/dist/client/content && nuxt generate --modern --fail-on-error && for f in dist/*.htm.html; do mv -- \"$f\" \"${f%.htm.html}.htm\"; done && for f in dist/*.html.html; do mv -- \"$f\" \"${f%.html.html}.html\"; done && for f in dist/ipad/*.html.html; do mv -- \"$f\" \"${f%.html.html}.html\"; done && node scripts/stamp-deploy-ref.mjs && node validate-generated-routes.mjs",
         "verify:deploy": "node scripts/verify-deploy.mjs"
     },
     "lint-staged": {

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
         "start": "nuxt start",
         "update:image-dimensions": "node update-image-width-height.mjs", 
         "validate:cms": "node validate-cms-relations.mjs",
-        "generate": "node validate-cms-relations.mjs && rm -rf node_modules/.cache && rm -rf dist && yarn cache clean --all && nuxt generate --modern && for f in dist/*.htm.html; do mv -- \"$f\" \"${f%.htm.html}.htm\"; done && for f in dist/*.html.html; do mv -- \"$f\" \"${f%.html.html}.html\"; done && for f in dist/ipad/*.html.html; do mv -- \"$f\" \"${f%.html.html}.html\"; done"
+        "generate": "node validate-cms-relations.mjs && rm -rf dist .nuxt/dist/client/content && nuxt generate --modern --fail-on-error && for f in dist/*.htm.html; do mv -- \"$f\" \"${f%.htm.html}.htm\"; done && for f in dist/*.html.html; do mv -- \"$f\" \"${f%.html.html}.html\"; done && for f in dist/ipad/*.html.html; do mv -- \"$f\" \"${f%.html.html}.html\"; done && node validate-generated-routes.mjs",
+        "verify:deploy": "node scripts/verify-deploy.mjs"
     },
     "lint-staged": {
         "*.{js,vue}": "eslint --cache",

--- a/pages/artist-bio.vue
+++ b/pages/artist-bio.vue
@@ -26,13 +26,13 @@
                         <div v-if="isSoldOrHold(painting)" class="sold">
                             <span class="soldTag">{{ soldOrHoldText(painting) }}</span>
                             <nuxt-link :to="`/${painting.replace('-html', '.html')}`"><nuxt-img provider="bedford"
-                                    :src="getGridImage(artist.paintingToObj[painting].gridImage)"
+                                    :src="getGridImage(artist.paintingToObj[painting])"
                                     :alt="nameWithTinyDescription" />
                             </nuxt-link>
                         </div>
                         <template v-else>
                             <nuxt-link :to="`/${painting.replace('-html', '.html')}`"><nuxt-img provider="bedford"
-                                    :src="getGridImage(artist.paintingToObj[painting].gridImage)"
+                                    :src="getGridImage(artist.paintingToObj[painting])"
                                     :alt="nameWithTinyDescription" />
                             </nuxt-link>
                         </template>
@@ -102,7 +102,7 @@ export default {
         artist.paintingToObj = await loadPaintings({
             $content,
             paintingSlugs: artist.paintings,
-            columns: ['slug', 'gridImage', 'status'],
+            columns: ['slug', 'galleryCropImage', 'gridImage', 'mediumResImage', 'status'],
         })
         return { artist }
     },
@@ -134,8 +134,8 @@ export default {
         soldOrHoldText(painting) {
             return this.artist.paintingToObj[painting].status.toLowerCase()
         },
-        getGridImage(image) {
-            return image
+        getGridImage(painting) {
+            return painting.galleryCropImage || painting.gridImage || painting.mediumResImage
         },
     },
     head() {

--- a/pages/customer-images-loop.vue
+++ b/pages/customer-images-loop.vue
@@ -976,10 +976,6 @@
     </div>
 </template>
 
-<script setup>
-import { useHead } from '#imports'
-</script>
-
 <script>
 import ArtworkSlidingImages from '~/components/ArtworkSlidingImages'
 import ArtworkSlidingImagesHome from '~/components/ArtworkSlidingImagesHome'
@@ -991,42 +987,6 @@ import TestimonialsScroll from '~/components/TestimonialsScroll'
 import YouTubeVideo from '~/components/YouTubeVideo'
 import { loadGalleryPaintings } from '~/libs/paintings'
 import { loadShortTestimonials } from '~/libs/testimonials'
-
-useHead({
-    script: [
-        {
-            type: 'application/ld+json',
-            children: JSON.stringify({
-                '@context': 'https://schema.org',
-                '@type': 'LocalBusiness',
-                name: 'Bedford Fine Art Gallery',
-                image: 'https://img.bedfordfineartgallery.com/logo.png',
-                '@id': '',
-                url: 'https://bedfordfineartgallery.com',
-                telephone: '724-459-0612',
-                address: {
-                    '@type': 'PostalAddress',
-                    streetAddress: '230 South Juliana St.',
-                    addressLocality: 'Bedford',
-                    addressRegion: 'PA',
-                    postalCode: '15522',
-                    addressCountry: 'US',
-                },
-                geo: {
-                    '@type': 'GeoCoordinates',
-                    latitude: 40.0160567,
-                    longitude: -78.5039377,
-                },
-                openingHoursSpecification: {
-                    '@type': 'OpeningHoursSpecification',
-                    dayOfWeek: ['Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday'],
-                    opens: '10:00',
-                    closes: '17:00',
-                },
-            }),
-        },
-    ],
-})
 
 const defaultConfig = {
     displayAmount: 4,
@@ -1105,17 +1065,6 @@ export default {
                 {
                     value: 'cubic-bezier(0.06, 0.29, 0.19, 1.4)',
                     label: 'cubic-bezier(0.06, 0.29, 0.19, 1.4)',
-                },
-            ],
-        }
-    },
-    head() {
-        return {
-            script: [
-                {
-                    src: 'https://identity.netlify.com/v1/netlify-identity-widget.js',
-                    async: true,
-                    defer: true,
                 },
             ],
         }

--- a/pages/index-old-april24.vue
+++ b/pages/index-old-april24.vue
@@ -999,17 +999,6 @@ export default {
             ],
         }
     },
-    head() {
-        return {
-            script: [
-                {
-                    src: 'https://identity.netlify.com/v1/netlify-identity-widget.js',
-                    async: true,
-                    defer: true,
-                },
-            ],
-        }
-    },
     computed: {
         diffConfig() {
             const keys = Object.keys(defaultConfig)

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -1109,17 +1109,6 @@ export default {
             ],
         }
     },
-    head() {
-        return {
-            script: [
-                {
-                    src: 'https://identity.netlify.com/v1/netlify-identity-widget.js',
-                    async: true,
-                    defer: true,
-                },
-            ],
-        }
-    },
     computed: {
         diffConfig() {
             const keys = Object.keys(defaultConfig)

--- a/pages/ipad/index.vue
+++ b/pages/ipad/index.vue
@@ -62,6 +62,6 @@ export default {
 
 <router>
   {
-    path: '/ipad/'
+    path: '/ipad'
   }
 </router>

--- a/plugins/referer.client.js
+++ b/plugins/referer.client.js
@@ -1,9 +1,17 @@
 import { v4 as uuidv4 } from 'uuid'
+import config from '~/config'
 import { getCookie, setCookie, setCookieIfNotEmpty } from '~/libs/cookie'
 import { googleConvert } from '~/libs/google-conversion'
 import NextLeadService from '~/services/NextLeadService'
 
 export default function setRefererOnAppLoad({ app }, inject) {
+    const hostname = window.location.hostname.toLowerCase()
+    const canonicalHostnames = new Set([config.domain, config.domain.replace(/^www\./, '')])
+
+    if (process.env.NODE_ENV === 'production' && !canonicalHostnames.has(hostname)) {
+        return
+    }
+
     const { referrer: referer } = document
     if (referer && new URL(referer).hostname.toLowerCase() !== window.location.hostname.toLowerCase()) {
         setCookieIfNotEmpty('referer', referer, 3650)

--- a/scripts/netlify-ignore-build.mjs
+++ b/scripts/netlify-ignore-build.mjs
@@ -1,0 +1,49 @@
+import { spawnSync } from 'node:child_process'
+
+const baseRef = process.env.CACHED_COMMIT_REF
+const headRef = process.env.COMMIT_REF
+
+function buildSite(reason) {
+    console.log(`Netlify build required: ${reason}`)
+    process.exit(1)
+}
+
+if (!baseRef || !headRef) {
+    buildSite('commit references are unavailable')
+}
+
+if (baseRef === headRef) {
+    buildSite('no prior cached commit is available for a safe comparison')
+}
+
+const diff = spawnSync('git', ['diff', '--name-only', '--diff-filter=ACMRTUXB', baseRef, headRef, '--'], {
+    encoding: 'utf8',
+})
+
+if (diff.status !== 0) {
+    buildSite(`Git comparison failed: ${diff.stderr.trim() || `exit ${diff.status}`}`)
+}
+
+const changedFiles = diff.stdout
+    .split('\n')
+    .map((file) => file.trim())
+    .filter(Boolean)
+
+if (changedFiles.length === 0) {
+    buildSite('the comparison returned no changed files')
+}
+
+const isDocumentationOnly = changedFiles.every((file) => {
+    return (
+        file.startsWith('migration/') ||
+        /^(AGENTS|README)(?:\.[^/]+)?\.(?:md|mdx|markdown)$/i.test(file) ||
+        /^(AGENTS|README)\.(?:md|mdx|markdown)$/i.test(file)
+    )
+})
+
+if (isDocumentationOnly) {
+    console.log(`Skipping Netlify build; only non-site documentation changed:\n${changedFiles.join('\n')}`)
+    process.exit(0)
+}
+
+buildSite(`site-affecting files changed:\n${changedFiles.join('\n')}`)

--- a/scripts/stamp-deploy-ref.mjs
+++ b/scripts/stamp-deploy-ref.mjs
@@ -5,6 +5,7 @@ const deployRef = process.env.COMMIT_REF || 'local'
 const outputRoot = path.join(process.cwd(), 'dist')
 const stampedPages = ['index.html', 'Artists--Bios.html']
 
+// CX_DEPLOY_PROOF_20260715: this source-only change should alter only the two stamped pages.
 if (!/^(?:[0-9a-f]{7,64}|local)$/i.test(deployRef)) {
     throw new Error(`Refusing to stamp invalid deploy ref: ${deployRef}`)
 }

--- a/scripts/stamp-deploy-ref.mjs
+++ b/scripts/stamp-deploy-ref.mjs
@@ -1,0 +1,24 @@
+import fs from 'node:fs'
+import path from 'node:path'
+
+const deployRef = process.env.COMMIT_REF || 'local'
+const outputRoot = path.join(process.cwd(), 'dist')
+const stampedPages = ['index.html', 'Artists--Bios.html']
+
+if (!/^(?:[0-9a-f]{7,64}|local)$/i.test(deployRef)) {
+    throw new Error(`Refusing to stamp invalid deploy ref: ${deployRef}`)
+}
+
+for (const page of stampedPages) {
+    const file = path.join(outputRoot, page)
+    const html = fs.readFileSync(file, 'utf8')
+    const marker = `<meta name="cx-deploy-ref" content="${deployRef}">`
+
+    if (!html.includes('</head>')) {
+        throw new Error(`Cannot stamp deploy ref because ${page} has no closing head tag.`)
+    }
+
+    fs.writeFileSync(file, html.replace('</head>', `${marker}</head>`))
+}
+
+console.log(`Stamped deploy ref ${deployRef} into ${stampedPages.join(' and ')}.`)

--- a/scripts/verify-deploy.mjs
+++ b/scripts/verify-deploy.mjs
@@ -9,6 +9,7 @@ const productionUrl = String(argumentsByName.get('--production-base') || process
 const commitRef = String(argumentsByName.get('--commit-ref') || process.env.COMMIT_REF || '')
 const context = String(process.env.CONTEXT || 'manual')
 const cacheBuster = Date.now()
+const knownDeadProductionPaths = new Set(['/art-lovers-niche-article', '/artist-bio', '/highlight', '/painting'])
 
 if (!baseUrl) {
     console.error('Deploy verification requires --base or DEPLOY_PRIME_URL.')
@@ -137,12 +138,34 @@ async function verifySitemapSuperset() {
     const previewPaths = sitemapPaths(await previewResponse.text())
     const productionPaths = sitemapPaths(await productionResponse.text())
     const missingPaths = [...productionPaths].filter((route) => !previewPaths.has(route)).sort()
+    const unexpectedMissingPaths = missingPaths.filter((route) => !knownDeadProductionPaths.has(route))
 
-    if (missingPaths.length > 0) {
-        throw new Error(`Preview sitemap dropped ${missingPaths.length} production route(s): ${missingPaths.join(', ')}`)
+    if (unexpectedMissingPaths.length > 0) {
+        throw new Error(
+            `Preview sitemap dropped ${unexpectedMissingPaths.length} production route(s): ${unexpectedMissingPaths.join(', ')}`
+        )
+    }
+
+    const removedDeadPaths = missingPaths.filter((route) => knownDeadProductionPaths.has(route))
+
+    for (const route of removedDeadPaths) {
+        const response = await fetch(`${productionUrl}${route}?cx_smoke=${cacheBuster}`, {
+            headers: {
+                'cache-control': 'no-cache',
+                'user-agent': 'Bedford deploy smoke verifier',
+            },
+        })
+
+        if (response.status !== 404) {
+            throw new Error(`Sitemap cleanup allowlist is stale: production ${route} returned ${response.status}`)
+        }
     }
 
     console.log(`PASS sitemap route preservation (${productionPaths.size} production routes retained)`)
+
+    if (removedDeadPaths.length > 0) {
+        console.log(`PASS sitemap dead-route cleanup (${removedDeadPaths.join(', ')})`)
+    }
 }
 
 async function verifyProductionIsolation() {

--- a/scripts/verify-deploy.mjs
+++ b/scripts/verify-deploy.mjs
@@ -1,0 +1,173 @@
+const argumentsByName = new Map()
+
+for (let index = 2; index < process.argv.length; index += 2) {
+    argumentsByName.set(process.argv[index], process.argv[index + 1])
+}
+
+const baseUrl = String(argumentsByName.get('--base') || process.env.DEPLOY_PRIME_URL || '').replace(/\/$/, '')
+const productionUrl = String(argumentsByName.get('--production-base') || process.env.URL || '').replace(/\/$/, '')
+const commitRef = String(argumentsByName.get('--commit-ref') || process.env.COMMIT_REF || '')
+const context = String(process.env.CONTEXT || 'manual')
+const cacheBuster = Date.now()
+
+if (!baseUrl) {
+    console.error('Deploy verification requires --base or DEPLOY_PRIME_URL.')
+    process.exit(1)
+}
+
+const checks = [
+    {
+        path: '/',
+        includes: [
+            'cx_site-header',
+            'cx_site-footer',
+            '/images/bedford-fine-art-gallery-logo-v3-250.png',
+        ],
+        excludes: ['identity.netlify.com/v1/netlify-identity-widget.js'],
+        verifyDeployRef: true,
+    },
+    {
+        path: '/Artists--Bios.html',
+        includes: ['cx_site-header', 'cx_site-footer'],
+        verifyDeployRef: true,
+    },
+    { path: '/Artists.html', includes: ['cx_site-header', 'cx_site-footer'] },
+    { path: '/Directions.html', includes: ['cx_site-header', 'cx_site-footer'] },
+    { path: '/faq.html', includes: ['cx_site-header', 'cx_site-footer'] },
+    { path: '/privacy.htm', includes: ['cx_site-header', 'cx_site-footer'] },
+    { path: '/art_lovers_niche.htm', includes: ['cx_site-header', 'cx_site-footer'] },
+    { path: '/notable_sales.html', includes: ['cx_site-header', 'cx_site-footer'] },
+    { path: '/landscape_artwork.html', includes: ['cx_site-header', 'cx_site-footer'] },
+    { path: '/victorian_art.html', includes: ['cx_site-header', 'cx_site-footer'] },
+    { path: '/ipad/', includes: ['Bedford Fine Art Gallery'] },
+    { path: '/admin/', includes: ['identity.netlify.com/v1/netlify-identity-widget.js'] },
+    {
+        path: '/george_t_hetzel_artist.html',
+        includes: ['George T. Hetzel', 'Deputy Recorder of Allegheny County'],
+    },
+    {
+        path: '/george_t_hetzel_burnished_forest_stream.html',
+        includes: ['George T. Hetzel', 'Burnished Forest Stream'],
+    },
+    {
+        path: '/george_t_hetzel_for_later.html',
+        includes: ['George T. Hetzel'],
+    },
+]
+
+function sleep(milliseconds) {
+    return new Promise((resolve) => setTimeout(resolve, milliseconds))
+}
+
+async function fetchWithRetry(url, attempts = 5) {
+    let lastError
+
+    for (let attempt = 1; attempt <= attempts; attempt += 1) {
+        try {
+            const response = await fetch(url, {
+                headers: {
+                    'cache-control': 'no-cache',
+                    'user-agent': 'Bedford deploy smoke verifier',
+                },
+            })
+
+            if (response.ok) {
+                return response
+            }
+
+            lastError = new Error(`${response.status} ${response.statusText}`)
+        } catch (error) {
+            lastError = error
+        }
+
+        if (attempt < attempts) {
+            await sleep(attempt * 1500)
+        }
+    }
+
+    throw lastError
+}
+
+function deployRefIsPresent(html) {
+    return html.includes('name="cx-deploy-ref"') && html.includes(`content="${commitRef}"`)
+}
+
+async function verifyPage(check) {
+    const separator = check.path.includes('?') ? '&' : '?'
+    const response = await fetchWithRetry(`${baseUrl}${check.path}${separator}cx_smoke=${cacheBuster}`)
+    const html = await response.text()
+
+    for (const expected of check.includes || []) {
+        if (!html.includes(expected)) {
+            throw new Error(`${check.path} is missing expected content: ${expected}`)
+        }
+    }
+
+    for (const forbidden of check.excludes || []) {
+        if (html.includes(forbidden)) {
+            throw new Error(`${check.path} contains forbidden content: ${forbidden}`)
+        }
+    }
+
+    if (check.verifyDeployRef && commitRef && !deployRefIsPresent(html)) {
+        throw new Error(`${check.path} does not identify deployed commit ${commitRef}`)
+    }
+
+    console.log(`PASS ${check.path}`)
+}
+
+function sitemapPaths(xml) {
+    return new Set(
+        [...xml.matchAll(/<loc>(.*?)<\/loc>/g)].map((match) => {
+            const value = match[1].replaceAll('&amp;', '&')
+            return new URL(value).pathname
+        })
+    )
+}
+
+async function verifySitemapSuperset() {
+    if (!productionUrl || productionUrl === baseUrl || context === 'production') {
+        return
+    }
+
+    const [previewResponse, productionResponse] = await Promise.all([
+        fetchWithRetry(`${baseUrl}/sitemap.xml?cx_smoke=${cacheBuster}`),
+        fetchWithRetry(`${productionUrl}/sitemap.xml?cx_smoke=${cacheBuster}`),
+    ])
+    const previewPaths = sitemapPaths(await previewResponse.text())
+    const productionPaths = sitemapPaths(await productionResponse.text())
+    const missingPaths = [...productionPaths].filter((route) => !previewPaths.has(route)).sort()
+
+    if (missingPaths.length > 0) {
+        throw new Error(`Preview sitemap dropped ${missingPaths.length} production route(s): ${missingPaths.join(', ')}`)
+    }
+
+    console.log(`PASS sitemap route preservation (${productionPaths.size} production routes retained)`)
+}
+
+async function verifyProductionIsolation() {
+    if (!productionUrl || productionUrl === baseUrl || !commitRef || context === 'production') {
+        return
+    }
+
+    const response = await fetchWithRetry(`${productionUrl}/?cx_smoke=${cacheBuster}`)
+    const productionHome = await response.text()
+
+    if (productionHome.includes(`content="${commitRef}"`)) {
+        throw new Error(`Production unexpectedly contains preview commit ${commitRef}`)
+    }
+
+    console.log('PASS production isolation')
+}
+
+try {
+    for (const check of checks) {
+        await verifyPage(check)
+    }
+    await verifySitemapSuperset()
+    await verifyProductionIsolation()
+    console.log(`Deploy verification passed for ${baseUrl}.`)
+} catch (error) {
+    console.error(`Deploy verification failed for ${baseUrl}: ${error.message}`)
+    process.exit(1)
+}

--- a/static/_headers
+++ b/static/_headers
@@ -3,3 +3,6 @@
 /_nuxt/*
   Cache-Control: max-age=365000000
   Cache-Control: immutable
+
+/_nuxt/static/*
+  Cache-Control: public,max-age=0,must-revalidate

--- a/validate-generated-routes.mjs
+++ b/validate-generated-routes.mjs
@@ -1,0 +1,74 @@
+import fs from 'node:fs'
+import path from 'node:path'
+
+const projectRoot = process.cwd()
+const outputRoot = path.join(projectRoot, 'dist')
+
+function loadCollection(name) {
+    const collectionDirectory = path.join(projectRoot, 'cms', name)
+    return fs.readdirSync(collectionDirectory).map((file) => {
+        return JSON.parse(fs.readFileSync(path.join(collectionDirectory, file), 'utf8'))
+    })
+}
+
+function routeOutputFile(slug, prefix = '') {
+    const route = slug.replace('-html', '.html')
+    const file = /\.html?$/.test(route) ? route : `${route}.html`
+    return path.join(prefix, file)
+}
+
+const expectedRoutes = new Set([
+    'index.html',
+    'Artists--Bios.html',
+    'Artists.html',
+    'Directions.html',
+    'Gallery-Value.html',
+    'faq.html',
+    'privacy.htm',
+    'art_lovers_niche.htm',
+    'notable_sales.html',
+    'landscape_artwork.html',
+    'victorian_art.html',
+    'ipad.html',
+    path.join('admin', 'index.html'),
+])
+
+const paintings = loadCollection('paintings')
+const artists = loadCollection('artists').filter((artist) => artist.hasLandingPage)
+const articles = loadCollection('articles')
+const artLoversNicheArticles = loadCollection('artLoversNicheArticles')
+
+for (const painting of paintings) {
+    expectedRoutes.add(routeOutputFile(painting.slug))
+    expectedRoutes.add(routeOutputFile(painting.slug, 'ipad'))
+}
+
+for (const artist of artists) {
+    expectedRoutes.add(routeOutputFile(artist.slug))
+}
+
+for (const article of articles) {
+    expectedRoutes.add(routeOutputFile(article.slug))
+}
+
+for (const article of artLoversNicheArticles) {
+    expectedRoutes.add(routeOutputFile(article.slug))
+}
+
+const missingRoutes = [...expectedRoutes]
+    .filter((route) => !fs.existsSync(path.join(outputRoot, route)))
+    .sort()
+
+if (missingRoutes.length > 0) {
+    console.error(`Generated route validation failed. Missing ${missingRoutes.length} expected public file(s):`)
+    for (const route of missingRoutes) {
+        console.error(`- ${route}`)
+    }
+    process.exit(1)
+}
+
+console.log(
+    `Generated route validation passed: ${expectedRoutes.size} files ` +
+        `(${paintings.length} paintings, ${artists.length} artists, ${articles.length} articles, ` +
+        `${artLoversNicheArticles.length} Art Lovers' Niche articles, and ${paintings.length} iPad paintings).`
+)


### PR DESCRIPTION
## Summary
- preserve Nuxt webpack cache and remove timestamp/order-driven full-site churn
- validate all 2,427 expected generated public routes and smoke-check deployed previews
- skip only conservative documentation-only builds
- restore `/george_t_hetzel_artist.html` using the existing biography and both painting records
- repair the iPad index output and remove public Netlify Identity loading

## Local proof
- strict generation passed all 2,427 expected routes
- repeat run reused webpack cache
- two repeat outputs: 7,611 files each, byte-for-byte identical
- production remains unchanged

Do not merge until the Deploy Preview and independent smoke checks pass.