### PR TITLE
Fix CMS publication of newly added painting routes

### DIFF
--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -174,9 +174,9 @@ export default {
     generate: {
         subFolders: false,
         crawler: true,
-        cache: {
-            ignore: ['migration/**'],
-        },
+        // Concrete CMS routes are added during webpack compilation, so a
+        // content save must always rebuild the router before generation.
+        cache: false,
         staticAssets: {
             version: staticAssetsVersion,
         },


### PR DESCRIPTION
## Cause

Nuxt Content excludes `cms/` from its incremental webpack snapshot. This site compiles concrete CMS URLs into the router, so Netlify reused a router that predated Joan's new painting even though the CMS file itself was present. The generated-route audit correctly blocked the incomplete deploy.

## Fix

Disable only Nuxt's unsafe incremental webpack shortcut. Netlify dependency caching and deterministic static output remain unchanged.

## Verification

- CMS relation validation: 403 artists, 877 paintings, 153 articles, 106 Art Lovers' Niche articles
- Two consecutive full generations passed 2,429 expected files
- Both `/robert_ward_van_boskerck_old_canal.html` and `/ipad/robert_ward_van_boskerck_old_canal.html` generated
- Same-commit repeat rebuilt instead of reporting `Skipping webpack build as no changes detected`