### PR TITLE
Validate CMS route slugs before save

### DIFF
--- a/static/admin/bedford-publish-site.js
+++ b/static/admin/bedford-publish-site.js
@@ -12,7 +12,12 @@
     var saveLabelObserverInstalled = false
     var slugProtectionInstalled = false
     var slugProtectionEventInstalled = false
-    var originalSlugByEntryKey = {}
+    var slugProtectedCollections = {
+        artists: true,
+        paintings: true,
+        articles: true,
+        artLoversNicheArticles: true,
+    }
     var currentPublishStatus = {
         state: 'checking',
         canPublish: false,
@@ -74,11 +79,21 @@
     function currentEntryKey() {
         var route = getEditorRoute()
 
-        if (!route.isExistingEntry || !route.collection || !route.entrySlug) {
+        if (!route.isExistingEntry || !slugProtectedCollections[route.collection] || !route.entrySlug) {
             return ''
         }
 
         return route.collection + ':' + route.entrySlug
+    }
+
+    function currentCanonicalSlug() {
+        var route = getEditorRoute()
+
+        if (!route.isExistingEntry || !slugProtectedCollections[route.collection]) {
+            return ''
+        }
+
+        return route.entrySlug || ''
     }
 
     function getIdentityUser() {
@@ -348,18 +363,12 @@
         return []
     }
 
-    function protectSlugControl(control, key) {
-        if (!control || !control.value) {
+    function protectSlugControl(control, key, canonicalSlug) {
+        if (!control || !canonicalSlug) {
             return
         }
 
-        if (!originalSlugByEntryKey[key]) {
-            originalSlugByEntryKey[key] = control.value
-        }
-
-        var originalSlug = originalSlugByEntryKey[key]
-
-        control.value = originalSlug
+        control.value = canonicalSlug
         control.readOnly = true
         control.setAttribute('aria-readonly', 'true')
         control.setAttribute('data-bedford-slug-protected', 'true')
@@ -387,8 +396,9 @@
 
     function protectExistingSlugFields(root) {
         var key = currentEntryKey()
+        var canonicalSlug = currentCanonicalSlug()
 
-        if (!key) {
+        if (!key || !canonicalSlug) {
             return
         }
 
@@ -407,23 +417,22 @@
 
         labels.forEach(function (label) {
             Array.prototype.forEach.call(findSlugControls(label), function (control) {
-                protectSlugControl(control, key)
+                protectSlugControl(control, key, canonicalSlug)
             })
         })
     }
 
     function protectEntrySlugBeforeSave(args) {
-        var key = currentEntryKey()
-        var originalSlug = key && originalSlugByEntryKey[key]
+        var canonicalSlug = currentCanonicalSlug()
         var entry = args && args.entry
         var data = entry && entry.get && entry.get('data')
 
-        if (!originalSlug || !data || !data.get || !data.set) {
+        if (!canonicalSlug || !data || !data.get || !data.set || data.get('slug') === undefined) {
             return data
         }
 
-        if (data.get('slug') !== originalSlug) {
-            return data.set('slug', originalSlug)
+        if (data.get('slug') !== canonicalSlug) {
+            return data.set('slug', canonicalSlug)
         }
 
         return data

--- a/static/admin/config.yml
+++ b/static/admin/config.yml
@@ -302,7 +302,7 @@ collections:
             fields:
                 - { label: 'Text', name: 'text', widget: 'string', required: false }
                 - { label: 'Link', name: 'link', widget: 'string', required: false }
-          - { label: 'Slug', name: 'slug', widget: 'string', hint: 'This controls the public URL. It is protected after creation. Ask the site maintainer if this URL must change.' }
+          - { label: 'Slug', name: 'slug', widget: 'string', required: true, hint: 'Example: arthur_v_diehl_a_most_interesting_artist_article-html. Use -html, not .html. This controls the public URL and is protected after creation. Ask the site maintainer if this URL must change.', pattern: ["^(\\w|-)+-html$", "Slug must contain only letters, numbers, dashes, or underscores, and must end in -html (not .html)"] }
           - {
                 label: 'Meta Title',
                 name: 'metaTitle',
@@ -349,7 +349,7 @@ collections:
                 hint: 'This will show on the highlights list page'
             }
           - { label: 'Body', name: 'body', widget: 'text' }
-          - { label: 'Slug', name: 'slug', widget: 'string', hint: 'This controls the public URL. It is protected after creation. Ask the site maintainer if this URL must change.' }
+          - { label: 'Slug', name: 'slug', widget: 'string', required: true, hint: 'Example: art_lovers_niche_112-html. Use -html, not .html. This controls the public URL and is protected after creation. Ask the site maintainer if this URL must change.', pattern: ["^(\\w|-)+-html$", "Slug must contain only letters, numbers, dashes, or underscores, and must end in -html (not .html)"] }
           - {
                 label: 'Meta Title',
                 name: 'metaTitle',


### PR DESCRIPTION
## Summary
- require valid `-html` route slugs for Articles and Art Lovers Niche entries before CMS Save
- use the existing entry route ID as the canonical slug during `preSave`
- leave the Save / Publish Site workflow unchanged

## Verification
- native slug patterns accept valid `-html` values and reject `.html`, spaces, slashes, and trailing text
- simulated `preSave` corrects a stale article slug to its entry ID and ignores unrelated collections
- full `yarn generate` passed: 2,434 generated files validated, including 878 iPad routes