### PR TITLE
Remove repetitive customer image alt text

### DIFF
--- a/components/CustomerSlidingImages.vue
+++ b/components/CustomerSlidingImages.vue
@@ -1,120 +1,120 @@
 <template>
-    <div>
+    <div aria-hidden="true">
         <VueSlickCarousel v-bind="settings">
-           <div><img src="https://img.bedfordfineartgallery.com/customer-images/1.jpg" width="290" height="200" alt="Bedford Fine Art Gallery Customers" loading="lazy"></div>
-<div><img src="https://img.bedfordfineartgallery.com/customer-images/2.jpg" width="290" height="200" alt="Couple smiling beside a 19th-century genre painting" loading="lazy"></div>
-<div><img src="https://img.bedfordfineartgallery.com/customer-images/3.jpg" width="290" height="200" alt="Smiling man holding a 19th-century landscape painting" loading="lazy"></div>
-<div><img src="https://img.bedfordfineartgallery.com/customer-images/4.jpg" width="290" height="200" alt="Happy lady posing with a 19th-century ocean landscape" loading="lazy"></div>
-<div><img src="https://img.bedfordfineartgallery.com/customer-images/5.jpg" width="290" height="200" alt="Proud man holding a classic 19th-century still life" loading="lazy"></div>
-<div><img src="https://img.bedfordfineartgallery.com/customer-images/6.jpg" width="290" height="200" alt="Smiling husband and wife posing with a framed antique marine painting" loading="lazy"></div>
-<div><img src="https://img.bedfordfineartgallery.com/customer-images/7.jpg" width="290" height="200" alt="Gentleman standing next to a large Victorian artwork" loading="lazy"></div>
-<div><img src="https://img.bedfordfineartgallery.com/customer-images/8.jpg" width="290" height="200" alt="Woman showing off her newly purchased contemporary artwork" loading="lazy"></div>
-<div><img src="https://img.bedfordfineartgallery.com/customer-images/9.jpg" width="290" height="200" alt="Two art lovers smiling with a framed antique painting" loading="lazy"></div>
-<div><img src="https://img.bedfordfineartgallery.com/customer-images/10.jpg" width="290" height="200" alt="Couple standing next to a beautiful 19th-century still life of flowers" loading="lazy"></div>
-<div><img src="https://img.bedfordfineartgallery.com/customer-images/11.jpg" width="290" height="200" alt="Smiling couple standing in front of a small, framed still life of fruit" loading="lazy"></div>
-<div><img src="https://img.bedfordfineartgallery.com/customer-images/12.jpg" width="290" height="200" alt="Happy man customer posing with a framed creek painting" loading="lazy"></div>
-<div><img src="https://img.bedfordfineartgallery.com/customer-images/65.jpg" width="290" height="200" alt="Happy male buyer holding a rustic farm painting" loading="lazy"></div>
-<div><img src="https://img.bedfordfineartgallery.com/customer-images/13.jpg" width="290" height="200" alt="Married couple with a classic 19th-century seascape" loading="lazy"></div>
-<div><img src="https://img.bedfordfineartgallery.com/customer-images/14.jpg" width="290" height="200" alt="Couple holding ornate gold-framed 19th-century artwork" loading="lazy"></div>
-<div><img src="https://img.bedfordfineartgallery.com/customer-images/15.jpg" width="290" height="200" alt="Smiling male with a mountain landscape painting" loading="lazy"></div>
-<div><img src="https://img.bedfordfineartgallery.com/customer-images/16.jpg" width="290" height="200" alt="Male art lover holding a historic political artwork" loading="lazy"></div>
-<div><img src="https://img.bedfordfineartgallery.com/customer-images/17.jpg" width="290" height="200" alt="Elegant woman standing next to a large Victorian flower painting" loading="lazy"></div>
-<div><img src="https://img.bedfordfineartgallery.com/customer-images/68.jpg" width="290" height="200" alt="Smiling man beside a 19th-century genre painting" loading="lazy"></div>
-<div><img src="https://img.bedfordfineartgallery.com/customer-images/18.jpg" width="290" height="200" alt="Husband and wife smiling next to a historic American landscape" loading="lazy"></div>
-<div><img src="https://img.bedfordfineartgallery.com/customer-images/19.jpg" width="290" height="200" alt="Smiling woman showcasing her new historical fine art piece" loading="lazy"></div>
-<div><img src="https://img.bedfordfineartgallery.com/customer-images/20.jpg" width="290" height="200" alt="Female art lover holding a historic political artwork" loading="lazy"></div>
-<div><img src="https://img.bedfordfineartgallery.com/customer-images/21.jpg" width="290" height="200" alt="Couple holding a beautiful 19th-century autumn landscape" loading="lazy"></div>
-<div><img src="https://img.bedfordfineartgallery.com/customer-images/22.jpg" width="290" height="200" alt="Man with painting of Theodore Roosevelt" loading="lazy"></div>
-<div><img src="https://img.bedfordfineartgallery.com/customer-images/23.jpg" width="290" height="200" alt="Female customer holding a contemporary realism landscape" loading="lazy"></div>
-<div><img src="https://img.bedfordfineartgallery.com/customer-images/24.jpg" width="290" height="200" alt="Gentleman with a framed painting of a coastal scene" loading="lazy"></div>
-<div><img src="https://img.bedfordfineartgallery.com/customer-images/67.jpg" width="290" height="200" alt="man holding 19th century artwork" loading="lazy"></div>
+           <div><img src="https://img.bedfordfineartgallery.com/customer-images/1.jpg" width="290" height="200" alt="" loading="lazy"></div>
+<div><img src="https://img.bedfordfineartgallery.com/customer-images/2.jpg" width="290" height="200" alt="" loading="lazy"></div>
+<div><img src="https://img.bedfordfineartgallery.com/customer-images/3.jpg" width="290" height="200" alt="" loading="lazy"></div>
+<div><img src="https://img.bedfordfineartgallery.com/customer-images/4.jpg" width="290" height="200" alt="" loading="lazy"></div>
+<div><img src="https://img.bedfordfineartgallery.com/customer-images/5.jpg" width="290" height="200" alt="" loading="lazy"></div>
+<div><img src="https://img.bedfordfineartgallery.com/customer-images/6.jpg" width="290" height="200" alt="" loading="lazy"></div>
+<div><img src="https://img.bedfordfineartgallery.com/customer-images/7.jpg" width="290" height="200" alt="" loading="lazy"></div>
+<div><img src="https://img.bedfordfineartgallery.com/customer-images/8.jpg" width="290" height="200" alt="" loading="lazy"></div>
+<div><img src="https://img.bedfordfineartgallery.com/customer-images/9.jpg" width="290" height="200" alt="" loading="lazy"></div>
+<div><img src="https://img.bedfordfineartgallery.com/customer-images/10.jpg" width="290" height="200" alt="" loading="lazy"></div>
+<div><img src="https://img.bedfordfineartgallery.com/customer-images/11.jpg" width="290" height="200" alt="" loading="lazy"></div>
+<div><img src="https://img.bedfordfineartgallery.com/customer-images/12.jpg" width="290" height="200" alt="" loading="lazy"></div>
+<div><img src="https://img.bedfordfineartgallery.com/customer-images/65.jpg" width="290" height="200" alt="" loading="lazy"></div>
+<div><img src="https://img.bedfordfineartgallery.com/customer-images/13.jpg" width="290" height="200" alt="" loading="lazy"></div>
+<div><img src="https://img.bedfordfineartgallery.com/customer-images/14.jpg" width="290" height="200" alt="" loading="lazy"></div>
+<div><img src="https://img.bedfordfineartgallery.com/customer-images/15.jpg" width="290" height="200" alt="" loading="lazy"></div>
+<div><img src="https://img.bedfordfineartgallery.com/customer-images/16.jpg" width="290" height="200" alt="" loading="lazy"></div>
+<div><img src="https://img.bedfordfineartgallery.com/customer-images/17.jpg" width="290" height="200" alt="" loading="lazy"></div>
+<div><img src="https://img.bedfordfineartgallery.com/customer-images/68.jpg" width="290" height="200" alt="" loading="lazy"></div>
+<div><img src="https://img.bedfordfineartgallery.com/customer-images/18.jpg" width="290" height="200" alt="" loading="lazy"></div>
+<div><img src="https://img.bedfordfineartgallery.com/customer-images/19.jpg" width="290" height="200" alt="" loading="lazy"></div>
+<div><img src="https://img.bedfordfineartgallery.com/customer-images/20.jpg" width="290" height="200" alt="" loading="lazy"></div>
+<div><img src="https://img.bedfordfineartgallery.com/customer-images/21.jpg" width="290" height="200" alt="" loading="lazy"></div>
+<div><img src="https://img.bedfordfineartgallery.com/customer-images/22.jpg" width="290" height="200" alt="" loading="lazy"></div>
+<div><img src="https://img.bedfordfineartgallery.com/customer-images/23.jpg" width="290" height="200" alt="" loading="lazy"></div>
+<div><img src="https://img.bedfordfineartgallery.com/customer-images/24.jpg" width="290" height="200" alt="" loading="lazy"></div>
+<div><img src="https://img.bedfordfineartgallery.com/customer-images/67.jpg" width="290" height="200" alt="" loading="lazy"></div>
 
-<div><img src="https://img.bedfordfineartgallery.com/customer-images/25.jpg" width="290" height="200" alt="Man posing with a classic 19th-century river scene" loading="lazy"></div>
-<div><img src="https://img.bedfordfineartgallery.com/customer-images/47.jpg" width="290" height="200" alt="Happy couple holding their newly purchased 19th-century landscape painting" loading="lazy"></div>
-<div><img src="https://img.bedfordfineartgallery.com/customer-images/64.jpg" width="290" height="200" alt="Proud man holding a 19th-century ocean scene painting" loading="lazy"></div>
-<div><img src="https://img.bedfordfineartgallery.com/customer-images/26.jpg" width="290" height="200" alt="Man posing with a victorian waterfall painting" loading="lazy"></div>
-<div><img src="https://img.bedfordfineartgallery.com/customer-images/27.jpg" width="290" height="200" alt="Happy lady holding a classic 19th-century portrait" loading="lazy"></div>
-<div><img src="https://img.bedfordfineartgallery.com/customer-images/28.jpg" width="290" height="200" alt="Smiling man showcasing his new historical fine art piece" loading="lazy"></div>
-<div><img src="https://img.bedfordfineartgallery.com/customer-images/50.jpg" width="290" height="200" alt="Man with 19th century landscape artwork" loading="lazy"></div>
-<div><img src="https://img.bedfordfineartgallery.com/customer-images/45.jpg" width="290" height="200" alt="Two happy customers holding a contemporary realism landscape" loading="lazy"></div>
-<div><img src="https://img.bedfordfineartgallery.com/customer-images/29.jpg" width="290" height="200" alt="Male gallery visitor posing with an antique forest landscape" loading="lazy"></div>
-<div><img src="https://img.bedfordfineartgallery.com/customer-images/61.jpg" width="290" height="200" alt="Man holding a detailed genre painting" loading="lazy"></div>
-<div><img src="https://img.bedfordfineartgallery.com/customer-images/30.jpg" width="290" height="200" alt="Two gentleman holding up their new victorian art" loading="lazy"></div>
-<div><img src="https://img.bedfordfineartgallery.com/customer-images/31.jpg" width="290" height="200" alt="Two gentleman holding up their new 19th century art" loading="lazy"></div>
-<div><img src="https://img.bedfordfineartgallery.com/customer-images/32.jpg" width="290" height="200" alt="Two gentleman holding up their new 19th century mountain landscape painting" loading="lazy"></div>
-<div><img src="https://img.bedfordfineartgallery.com/customer-images/33.jpg" width="290" height="200" alt="Happy gentleman posing with a 19th-century river landscape" loading="lazy"></div>
-<div><img src="https://img.bedfordfineartgallery.com/customer-images/46.jpg" width="290" height="200" alt="Proud man displaying his new art purchases in his home" loading="lazy"></div>
-<div><img src="https://img.bedfordfineartgallery.com/customer-images/59.jpg" width="290" height="200" alt="Bedford Fine Art Gallery Customers" loading="lazy"></div>
-<div><img src="https://img.bedfordfineartgallery.com/customer-images/34.jpg" width="290" height="200" alt="Bedford Fine Art Gallery Customers" loading="lazy"></div>
-<div><img src="https://img.bedfordfineartgallery.com/customer-images/35.jpg" width="290" height="200" alt="Bedford Fine Art Gallery Customers" loading="lazy"></div>
-<div><img src="https://img.bedfordfineartgallery.com/customer-images/63.jpg" width="290" height="200" alt="Bedford Fine Art Gallery Customers" loading="lazy"></div>
-<div><img src="https://img.bedfordfineartgallery.com/customer-images/43.jpg" width="290" height="200" alt="Bedford Fine Art Gallery Customers" loading="lazy"></div>
-<div><img src="https://img.bedfordfineartgallery.com/customer-images/49.jpg" width="290" height="200" alt="Bedford Fine Art Gallery Customers" loading="lazy"></div>
-<div><img src="https://img.bedfordfineartgallery.com/customer-images/56.jpg" width="290" height="200" alt="Bedford Fine Art Gallery Customers" loading="lazy"></div>
-<div><img src="https://img.bedfordfineartgallery.com/customer-images/76.jpg" width="290" height="200" alt="Bedford Fine Art Gallery Customers" loading="lazy"></div>
-<div><img src="https://img.bedfordfineartgallery.com/customer-images/36.jpg" width="290" height="200" alt="Bedford Fine Art Gallery Customers" loading="lazy"></div>
-<div><img src="https://img.bedfordfineartgallery.com/customer-images/37.jpg" width="290" height="200" alt="Bedford Fine Art Gallery Customers" loading="lazy"></div>
-<div><img src="https://img.bedfordfineartgallery.com/customer-images/66.jpg" width="290" height="200" alt="Bedford Fine Art Gallery Customers" loading="lazy"></div>
-<div><img src="https://img.bedfordfineartgallery.com/customer-images/38.jpg" width="290" height="200" alt="Bedford Fine Art Gallery Customers" loading="lazy"></div>
-<div><img src="https://img.bedfordfineartgallery.com/customer-images/39.jpg" width="290" height="200" alt="Bedford Fine Art Gallery Customers" loading="lazy"></div>
-<div><img src="https://img.bedfordfineartgallery.com/customer-images/40.jpg" width="290" height="200" alt="Bedford Fine Art Gallery Customers" loading="lazy"></div>
-<div><img src="https://img.bedfordfineartgallery.com/customer-images/58.jpg" width="290" height="200" alt="Bedford Fine Art Gallery Customers" loading="lazy"></div>
-<div><img src="https://img.bedfordfineartgallery.com/customer-images/75.jpg" width="290" height="200" alt="Bedford Fine Art Gallery Customers" loading="lazy"></div>
-<div><img src="https://img.bedfordfineartgallery.com/customer-images/41.jpg" width="290" height="200" alt="Bedford Fine Art Gallery Customers" loading="lazy"></div>
-<div><img src="https://img.bedfordfineartgallery.com/customer-images/42.jpg" width="290" height="200" alt="Bedford Fine Art Gallery Customers" loading="lazy"></div>
-<div><img src="https://img.bedfordfineartgallery.com/customer-images/44.jpg" width="290" height="200" alt="Bedford Fine Art Gallery Customers" loading="lazy"></div>
-<div><img src="https://img.bedfordfineartgallery.com/customer-images/51.jpg" width="290" height="200" alt="Bedford Fine Art Gallery Customers" loading="lazy"></div>
-<div><img src="https://img.bedfordfineartgallery.com/customer-images/52.jpg" width="290" height="200" alt="Bedford Fine Art Gallery Customers" loading="lazy"></div>
-<div><img src="https://img.bedfordfineartgallery.com/customer-images/85.jpg" width="290" height="200" alt="Bedford Fine Art Gallery Customers" loading="lazy"></div>
-<div><img src="https://img.bedfordfineartgallery.com/customer-images/53.jpg" width="290" height="200" alt="Bedford Fine Art Gallery Customers" loading="lazy"></div>
-<div><img src="https://img.bedfordfineartgallery.com/customer-images/80.jpg" width="290" height="200" alt="Bedford Fine Art Gallery Customers" loading="lazy"></div>
-<div><img src="https://img.bedfordfineartgallery.com/customer-images/54.jpg" width="290" height="200" alt="Bedford Fine Art Gallery Customers" loading="lazy"></div>
-<div><img src="https://img.bedfordfineartgallery.com/customer-images/55.jpg" width="290" height="200" alt="Bedford Fine Art Gallery Customers" loading="lazy"></div>
-<div><img src="https://img.bedfordfineartgallery.com/customer-images/57.jpg" width="290" height="200" alt="Bedford Fine Art Gallery Customers" loading="lazy"></div>
-<div><img src="https://img.bedfordfineartgallery.com/customer-images/81.jpg" width="290" height="200" alt="Bedford Fine Art Gallery Customers" loading="lazy"></div>
+<div><img src="https://img.bedfordfineartgallery.com/customer-images/25.jpg" width="290" height="200" alt="" loading="lazy"></div>
+<div><img src="https://img.bedfordfineartgallery.com/customer-images/47.jpg" width="290" height="200" alt="" loading="lazy"></div>
+<div><img src="https://img.bedfordfineartgallery.com/customer-images/64.jpg" width="290" height="200" alt="" loading="lazy"></div>
+<div><img src="https://img.bedfordfineartgallery.com/customer-images/26.jpg" width="290" height="200" alt="" loading="lazy"></div>
+<div><img src="https://img.bedfordfineartgallery.com/customer-images/27.jpg" width="290" height="200" alt="" loading="lazy"></div>
+<div><img src="https://img.bedfordfineartgallery.com/customer-images/28.jpg" width="290" height="200" alt="" loading="lazy"></div>
+<div><img src="https://img.bedfordfineartgallery.com/customer-images/50.jpg" width="290" height="200" alt="" loading="lazy"></div>
+<div><img src="https://img.bedfordfineartgallery.com/customer-images/45.jpg" width="290" height="200" alt="" loading="lazy"></div>
+<div><img src="https://img.bedfordfineartgallery.com/customer-images/29.jpg" width="290" height="200" alt="" loading="lazy"></div>
+<div><img src="https://img.bedfordfineartgallery.com/customer-images/61.jpg" width="290" height="200" alt="" loading="lazy"></div>
+<div><img src="https://img.bedfordfineartgallery.com/customer-images/30.jpg" width="290" height="200" alt="" loading="lazy"></div>
+<div><img src="https://img.bedfordfineartgallery.com/customer-images/31.jpg" width="290" height="200" alt="" loading="lazy"></div>
+<div><img src="https://img.bedfordfineartgallery.com/customer-images/32.jpg" width="290" height="200" alt="" loading="lazy"></div>
+<div><img src="https://img.bedfordfineartgallery.com/customer-images/33.jpg" width="290" height="200" alt="" loading="lazy"></div>
+<div><img src="https://img.bedfordfineartgallery.com/customer-images/46.jpg" width="290" height="200" alt="" loading="lazy"></div>
+<div><img src="https://img.bedfordfineartgallery.com/customer-images/59.jpg" width="290" height="200" alt="" loading="lazy"></div>
+<div><img src="https://img.bedfordfineartgallery.com/customer-images/34.jpg" width="290" height="200" alt="" loading="lazy"></div>
+<div><img src="https://img.bedfordfineartgallery.com/customer-images/35.jpg" width="290" height="200" alt="" loading="lazy"></div>
+<div><img src="https://img.bedfordfineartgallery.com/customer-images/63.jpg" width="290" height="200" alt="" loading="lazy"></div>
+<div><img src="https://img.bedfordfineartgallery.com/customer-images/43.jpg" width="290" height="200" alt="" loading="lazy"></div>
+<div><img src="https://img.bedfordfineartgallery.com/customer-images/49.jpg" width="290" height="200" alt="" loading="lazy"></div>
+<div><img src="https://img.bedfordfineartgallery.com/customer-images/56.jpg" width="290" height="200" alt="" loading="lazy"></div>
+<div><img src="https://img.bedfordfineartgallery.com/customer-images/76.jpg" width="290" height="200" alt="" loading="lazy"></div>
+<div><img src="https://img.bedfordfineartgallery.com/customer-images/36.jpg" width="290" height="200" alt="" loading="lazy"></div>
+<div><img src="https://img.bedfordfineartgallery.com/customer-images/37.jpg" width="290" height="200" alt="" loading="lazy"></div>
+<div><img src="https://img.bedfordfineartgallery.com/customer-images/66.jpg" width="290" height="200" alt="" loading="lazy"></div>
+<div><img src="https://img.bedfordfineartgallery.com/customer-images/38.jpg" width="290" height="200" alt="" loading="lazy"></div>
+<div><img src="https://img.bedfordfineartgallery.com/customer-images/39.jpg" width="290" height="200" alt="" loading="lazy"></div>
+<div><img src="https://img.bedfordfineartgallery.com/customer-images/40.jpg" width="290" height="200" alt="" loading="lazy"></div>
+<div><img src="https://img.bedfordfineartgallery.com/customer-images/58.jpg" width="290" height="200" alt="" loading="lazy"></div>
+<div><img src="https://img.bedfordfineartgallery.com/customer-images/75.jpg" width="290" height="200" alt="" loading="lazy"></div>
+<div><img src="https://img.bedfordfineartgallery.com/customer-images/41.jpg" width="290" height="200" alt="" loading="lazy"></div>
+<div><img src="https://img.bedfordfineartgallery.com/customer-images/42.jpg" width="290" height="200" alt="" loading="lazy"></div>
+<div><img src="https://img.bedfordfineartgallery.com/customer-images/44.jpg" width="290" height="200" alt="" loading="lazy"></div>
+<div><img src="https://img.bedfordfineartgallery.com/customer-images/51.jpg" width="290" height="200" alt="" loading="lazy"></div>
+<div><img src="https://img.bedfordfineartgallery.com/customer-images/52.jpg" width="290" height="200" alt="" loading="lazy"></div>
+<div><img src="https://img.bedfordfineartgallery.com/customer-images/85.jpg" width="290" height="200" alt="" loading="lazy"></div>
+<div><img src="https://img.bedfordfineartgallery.com/customer-images/53.jpg" width="290" height="200" alt="" loading="lazy"></div>
+<div><img src="https://img.bedfordfineartgallery.com/customer-images/80.jpg" width="290" height="200" alt="" loading="lazy"></div>
+<div><img src="https://img.bedfordfineartgallery.com/customer-images/54.jpg" width="290" height="200" alt="" loading="lazy"></div>
+<div><img src="https://img.bedfordfineartgallery.com/customer-images/55.jpg" width="290" height="200" alt="" loading="lazy"></div>
+<div><img src="https://img.bedfordfineartgallery.com/customer-images/57.jpg" width="290" height="200" alt="" loading="lazy"></div>
+<div><img src="https://img.bedfordfineartgallery.com/customer-images/81.jpg" width="290" height="200" alt="" loading="lazy"></div>
 
-<div><img src="https://img.bedfordfineartgallery.com/customer-images/60.jpg" width="290" height="200" alt="Bedford Fine Art Gallery Customers" loading="lazy"></div>
-<div><img src="https://img.bedfordfineartgallery.com/customer-images/62.jpg" width="290" height="200" alt="Bedford Fine Art Gallery Customers" loading="lazy"></div>
-<div><img src="https://img.bedfordfineartgallery.com/customer-images/69.jpg" width="290" height="200" alt="Bedford Fine Art Gallery Customers" loading="lazy"></div>
-<div><img src="https://img.bedfordfineartgallery.com/customer-images/70.jpg" width="290" height="200" alt="Bedford Fine Art Gallery Customers" loading="lazy"></div>
-<div><img src="https://img.bedfordfineartgallery.com/customer-images/71.jpg" width="290" height="200" alt="Bedford Fine Art Gallery Customers" loading="lazy"></div>
-<div><img src="https://img.bedfordfineartgallery.com/customer-images/72.jpg" width="290" height="200" alt="Bedford Fine Art Gallery Customers" loading="lazy"></div>
-<div><img src="https://img.bedfordfineartgallery.com/customer-images/73.jpg" width="290" height="200" alt="Bedford Fine Art Gallery Customers" loading="lazy"></div>
-<div><img src="https://img.bedfordfineartgallery.com/customer-images/74.jpg" width="290" height="200" alt="Bedford Fine Art Gallery Customers" loading="lazy"></div>
-<div><img src="https://img.bedfordfineartgallery.com/customer-images/77.jpg" width="290" height="200" alt="Bedford Fine Art Gallery Customers" loading="lazy"></div>
-<div><img src="https://img.bedfordfineartgallery.com/customer-images/78.jpg" width="290" height="200" alt="Bedford Fine Art Gallery Customers" loading="lazy"></div>
-<div><img src="https://img.bedfordfineartgallery.com/customer-images/79.jpg" width="290" height="200" alt="Bedford Fine Art Gallery Customers" loading="lazy"></div>
-<div><img src="https://img.bedfordfineartgallery.com/customer-images/93.jpg" width="290" height="200" alt="Bedford Fine Art Gallery Customers" loading="lazy"></div>
+<div><img src="https://img.bedfordfineartgallery.com/customer-images/60.jpg" width="290" height="200" alt="" loading="lazy"></div>
+<div><img src="https://img.bedfordfineartgallery.com/customer-images/62.jpg" width="290" height="200" alt="" loading="lazy"></div>
+<div><img src="https://img.bedfordfineartgallery.com/customer-images/69.jpg" width="290" height="200" alt="" loading="lazy"></div>
+<div><img src="https://img.bedfordfineartgallery.com/customer-images/70.jpg" width="290" height="200" alt="" loading="lazy"></div>
+<div><img src="https://img.bedfordfineartgallery.com/customer-images/71.jpg" width="290" height="200" alt="" loading="lazy"></div>
+<div><img src="https://img.bedfordfineartgallery.com/customer-images/72.jpg" width="290" height="200" alt="" loading="lazy"></div>
+<div><img src="https://img.bedfordfineartgallery.com/customer-images/73.jpg" width="290" height="200" alt="" loading="lazy"></div>
+<div><img src="https://img.bedfordfineartgallery.com/customer-images/74.jpg" width="290" height="200" alt="" loading="lazy"></div>
+<div><img src="https://img.bedfordfineartgallery.com/customer-images/77.jpg" width="290" height="200" alt="" loading="lazy"></div>
+<div><img src="https://img.bedfordfineartgallery.com/customer-images/78.jpg" width="290" height="200" alt="" loading="lazy"></div>
+<div><img src="https://img.bedfordfineartgallery.com/customer-images/79.jpg" width="290" height="200" alt="" loading="lazy"></div>
+<div><img src="https://img.bedfordfineartgallery.com/customer-images/93.jpg" width="290" height="200" alt="" loading="lazy"></div>
 
-<div><img src="https://img.bedfordfineartgallery.com/customer-images/90.jpg" width="290" height="200" alt="Bedford Fine Art Gallery Customers" loading="lazy"></div>
-<div><img src="https://img.bedfordfineartgallery.com/customer-images/93.jpg" width="290" height="200" alt="Bedford Fine Art Gallery Customers" loading="lazy"></div>
+<div><img src="https://img.bedfordfineartgallery.com/customer-images/90.jpg" width="290" height="200" alt="" loading="lazy"></div>
+<div><img src="https://img.bedfordfineartgallery.com/customer-images/93.jpg" width="290" height="200" alt="" loading="lazy"></div>
 
-<div><img src="https://img.bedfordfineartgallery.com/customer-images/91.jpg" width="290" height="200" alt="Bedford Fine Art Gallery Customers" loading="lazy"></div> <!-- first 90 changed to 91 -->
+<div><img src="https://img.bedfordfineartgallery.com/customer-images/91.jpg" width="290" height="200" alt="" loading="lazy"></div> <!-- first 90 changed to 91 -->
 
-<div><img src="https://img.bedfordfineartgallery.com/customer-images/113.jpg" width="290" height="200" alt="Bedford Fine Art Gallery Customers" loading="lazy"></div>
+<div><img src="https://img.bedfordfineartgallery.com/customer-images/113.jpg" width="290" height="200" alt="" loading="lazy"></div>
 
-<div><img src="https://img.bedfordfineartgallery.com/customer-images/92.jpg" width="290" height="200" alt="Bedford Fine Art Gallery Customers" loading="lazy"></div>
-<div><img src="https://img.bedfordfineartgallery.com/customer-images/108.jpg" width="290" height="200" alt="Bedford Fine Art Gallery Customers" loading="lazy"></div>
-<div><img src="https://img.bedfordfineartgallery.com/customer-images/94.jpg" width="290" height="200" alt="Bedford Fine Art Gallery Customers" loading="lazy"></div>
-<div><img src="https://img.bedfordfineartgallery.com/customer-images/97.jpg" width="290" height="200" alt="Bedford Fine Art Gallery Customers" loading="lazy"></div>
-<div><img src="https://img.bedfordfineartgallery.com/customer-images/98.jpg" width="290" height="200" alt="Bedford Fine Art Gallery Customers" loading="lazy"></div>
-<div><img src="https://img.bedfordfineartgallery.com/customer-images/99_zwy5rn.jpg" width="290" height="200" alt="Bedford Fine Art Gallery Customers" loading="lazy"></div>
-<div><img src="https://img.bedfordfineartgallery.com/customer-images/111.jpg" width="290" height="200" alt="Bedford Fine Art Gallery Customers" loading="lazy"></div>
-<div><img src="https://img.bedfordfineartgallery.com/customer-images/100.jpg" width="290" height="200" alt="Bedford Fine Art Gallery Customers" loading="lazy"></div>
-<div><img src="https://img.bedfordfineartgallery.com/customer-images/119.jpg" width="290" height="200" alt="Bedford Fine Art Gallery Customers" loading="lazy"></div>
+<div><img src="https://img.bedfordfineartgallery.com/customer-images/92.jpg" width="290" height="200" alt="" loading="lazy"></div>
+<div><img src="https://img.bedfordfineartgallery.com/customer-images/108.jpg" width="290" height="200" alt="" loading="lazy"></div>
+<div><img src="https://img.bedfordfineartgallery.com/customer-images/94.jpg" width="290" height="200" alt="" loading="lazy"></div>
+<div><img src="https://img.bedfordfineartgallery.com/customer-images/97.jpg" width="290" height="200" alt="" loading="lazy"></div>
+<div><img src="https://img.bedfordfineartgallery.com/customer-images/98.jpg" width="290" height="200" alt="" loading="lazy"></div>
+<div><img src="https://img.bedfordfineartgallery.com/customer-images/99_zwy5rn.jpg" width="290" height="200" alt="" loading="lazy"></div>
+<div><img src="https://img.bedfordfineartgallery.com/customer-images/111.jpg" width="290" height="200" alt="" loading="lazy"></div>
+<div><img src="https://img.bedfordfineartgallery.com/customer-images/100.jpg" width="290" height="200" alt="" loading="lazy"></div>
+<div><img src="https://img.bedfordfineartgallery.com/customer-images/119.jpg" width="290" height="200" alt="" loading="lazy"></div>
 
-<div><img src="https://img.bedfordfineartgallery.com/customer-images/103.jpg" width="290" height="200" alt="Bedford Fine Art Gallery Customers" loading="lazy"></div>
-<div><img src="https://img.bedfordfineartgallery.com/customer-images/104.jpg" width="290" height="200" alt="Bedford Fine Art Gallery Customers" loading="lazy"></div>
-<div><img src="https://img.bedfordfineartgallery.com/customer-images/105.jpg" width="290" height="200" alt="Bedford Fine Art Gallery Customers" loading="lazy"></div>
-<div><img src="https://img.bedfordfineartgallery.com/customer-images/106.jpg" width="290" height="200" alt="Bedford Fine Art Gallery Customers" loading="lazy"></div>
-<div><img src="https://img.bedfordfineartgallery.com/customer-images/109.jpg" width="290" height="200" alt="Bedford Fine Art Gallery Customers" loading="lazy"></div>
-<div><img src="https://img.bedfordfineartgallery.com/customer-images/112.jpg" width="290" height="200" alt="Bedford Fine Art Gallery Customers" loading="lazy"></div>
+<div><img src="https://img.bedfordfineartgallery.com/customer-images/103.jpg" width="290" height="200" alt="" loading="lazy"></div>
+<div><img src="https://img.bedfordfineartgallery.com/customer-images/104.jpg" width="290" height="200" alt="" loading="lazy"></div>
+<div><img src="https://img.bedfordfineartgallery.com/customer-images/105.jpg" width="290" height="200" alt="" loading="lazy"></div>
+<div><img src="https://img.bedfordfineartgallery.com/customer-images/106.jpg" width="290" height="200" alt="" loading="lazy"></div>
+<div><img src="https://img.bedfordfineartgallery.com/customer-images/109.jpg" width="290" height="200" alt="" loading="lazy"></div>
+<div><img src="https://img.bedfordfineartgallery.com/customer-images/112.jpg" width="290" height="200" alt="" loading="lazy"></div>
 
-<div><img src="https://img.bedfordfineartgallery.com/customer-images/115.jpg" width="290" height="200" alt="Bedford Fine Art Gallery Customers" loading="lazy"></div>
-<div><img src="https://img.bedfordfineartgallery.com/customer-images/116.jpg" width="290" height="200" alt="Bedford Fine Art Gallery Customers" loading="lazy"></div>
-<div><img src="https://img.bedfordfineartgallery.com/customer-images/117.jpg" width="290" height="200" alt="Bedford Fine Art Gallery Customers" loading="lazy"></div>
-          <div><img src="https://img.bedfordfineartgallery.com/customer-images/118.jpg" width="290" height="200" alt="Bedford Fine Art Gallery Customers" loading="lazy"></div>
-          <div><img src="https://img.bedfordfineartgallery.com/customer-images/120.jpg" width="290" height="200" alt="Bedford Fine Art Gallery Customers" loading="lazy"></div>
+<div><img src="https://img.bedfordfineartgallery.com/customer-images/115.jpg" width="290" height="200" alt="" loading="lazy"></div>
+<div><img src="https://img.bedfordfineartgallery.com/customer-images/116.jpg" width="290" height="200" alt="" loading="lazy"></div>
+<div><img src="https://img.bedfordfineartgallery.com/customer-images/117.jpg" width="290" height="200" alt="" loading="lazy"></div>
+          <div><img src="https://img.bedfordfineartgallery.com/customer-images/118.jpg" width="290" height="200" alt="" loading="lazy"></div>
+          <div><img src="https://img.bedfordfineartgallery.com/customer-images/120.jpg" width="290" height="200" alt="" loading="lazy"></div>
 
 
                      

--- a/components/home/HomeImageMarquee.vue
+++ b/components/home/HomeImageMarquee.vue
@@ -3,7 +3,8 @@
         class="bfa-marquee"
         :class="`bfa-marquee--${variant}`"
         :style="marqueeStyle"
-        :aria-label="label"
+        :aria-label="decorative ? null : label"
+        :aria-hidden="decorative ? 'true' : null"
     >
         <div class="bfa-marquee__track">
             <div v-for="group in 2" :key="group" class="bfa-marquee__group" :aria-hidden="group === 2 ? 'true' : null">
@@ -17,7 +18,7 @@
                 >
                     <img
                         :src="image.src"
-                        :alt="image.alt || ''"
+                        :alt="decorative ? '' : (image.alt || '')"
                         :width="image.width || 290"
                         :height="image.height || 200"
                         loading="lazy"
@@ -59,6 +60,10 @@ export default {
         variant: {
             type: String,
             default: 'artwork',
+        },
+        decorative: {
+            type: Boolean,
+            default: false,
         },
     },
     computed: {

--- a/components/home/HomeRedesign.vue
+++ b/components/home/HomeRedesign.vue
@@ -30,7 +30,12 @@
             </section>
 
             <section class="bfa-home__panel bfa-home__panel--dark bfa-home__testimonials" aria-labelledby="bfa-home-testimonials-title">
-                <HomeImageMarquee :images="customerImages" label="Bedford Fine Art Gallery customers with their paintings" variant="customers" />
+                <HomeImageMarquee
+                    :images="customerImages"
+                    label="Bedford Fine Art Gallery customers with their paintings"
+                    variant="customers"
+                    decorative
+                />
                 <h2 id="bfa-home-testimonials-title" class="bfa-home__section-title">
                     Our customers are the best. Here's what they have to say.
                 </h2>
@@ -344,7 +349,7 @@ export default {
         customerImages() {
             return customerImageFiles.map((file) => ({
                 src: `https://img.bedfordfineartgallery.com/customer-images/${file}`,
-                alt: 'Bedford Fine Art Gallery customer with fine art',
+                alt: '',
                 width: 290,
                 height: 200,
             }))

--- a/package.json
+++ b/package.json
@@ -6,8 +6,9 @@
         "dev": "node validate-cms-relations.mjs && nuxt",
         "build": "nuxt build",
         "start": "nuxt start",
-        "update:image-dimensions": "node update-image-width-height.mjs", 
+        "update:image-dimensions": "node update-image-width-height.mjs",
         "validate:cms": "node validate-cms-relations.mjs",
+        "verify:customer-alt": "node scripts/verify-customer-alt-text.mjs",
         "generate": "node validate-cms-relations.mjs && rm -rf dist .nuxt/dist/client/content && nuxt generate --modern --fail-on-error && for f in dist/*.htm.html; do mv -- \"$f\" \"${f%.htm.html}.htm\"; done && for f in dist/*.html.html; do mv -- \"$f\" \"${f%.html.html}.html\"; done && for f in dist/ipad/*.html.html; do mv -- \"$f\" \"${f%.html.html}.html\"; done && node scripts/stamp-deploy-ref.mjs && node validate-generated-routes.mjs",
         "verify:deploy": "node scripts/verify-deploy.mjs"
     },

--- a/scripts/verify-customer-alt-text.mjs
+++ b/scripts/verify-customer-alt-text.mjs
@@ -1,0 +1,43 @@
+import assert from 'node:assert/strict'
+import { readFile } from 'node:fs/promises'
+
+const homepagePath = new URL('../components/home/HomeRedesign.vue', import.meta.url)
+const marqueePath = new URL('../components/home/HomeImageMarquee.vue', import.meta.url)
+
+const [homepage, marquee] = await Promise.all([
+    readFile(homepagePath, 'utf8'),
+    readFile(marqueePath, 'utf8'),
+])
+
+assert.equal(
+    homepage.includes('Bedford Fine Art Gallery customer with fine art'),
+    false,
+    'Homepage still contains the repeated customer-image alt text.'
+)
+assert.match(
+    homepage,
+    /<HomeImageMarquee[\s\S]*?variant="customers"[\s\S]*?\bdecorative\b[\s\S]*?\/>/,
+    'Homepage customer marquee must opt into decorative mode.'
+)
+assert.match(
+    homepage,
+    /customerImages\(\)[\s\S]*?alt:\s*''/,
+    'Homepage customer image records must use empty alt text.'
+)
+assert.match(
+    marquee,
+    /decorative:\s*\{[\s\S]*?type:\s*Boolean[\s\S]*?default:\s*false/,
+    'HomeImageMarquee must expose an explicit decorative Boolean prop.'
+)
+assert.match(
+    marquee,
+    /:aria-hidden="decorative \? 'true' : null"/,
+    'Decorative marquee content must be hidden from assistive technology.'
+)
+assert.match(
+    marquee,
+    /:alt="decorative \? '' : \(image\.alt \|\| ''\)"/,
+    'Decorative marquee images must render explicit empty alt text.'
+)
+
+console.log('Customer image alt-text source verification passed.')

--- a/scripts/verify-customer-alt-text.mjs
+++ b/scripts/verify-customer-alt-text.mjs
@@ -3,10 +3,12 @@ import { readFile } from 'node:fs/promises'
 
 const homepagePath = new URL('../components/home/HomeRedesign.vue', import.meta.url)
 const marqueePath = new URL('../components/home/HomeImageMarquee.vue', import.meta.url)
+const legacySliderPath = new URL('../components/CustomerSlidingImages.vue', import.meta.url)
 
-const [homepage, marquee] = await Promise.all([
+const [homepage, marquee, legacySlider] = await Promise.all([
     readFile(homepagePath, 'utf8'),
     readFile(marqueePath, 'utf8'),
+    readFile(legacySliderPath, 'utf8'),
 ])
 
 assert.equal(
@@ -40,4 +42,25 @@ assert.match(
     'Decorative marquee images must render explicit empty alt text.'
 )
 
+const legacyImageCount = (legacySlider.match(/<img\b/g) || []).length
+const legacyEmptyAltCount = (legacySlider.match(/\balt=""/g) || []).length
+
+assert.ok(legacyImageCount > 0, 'Legacy customer slider must still contain its images.')
+assert.equal(
+    legacyEmptyAltCount,
+    legacyImageCount,
+    'Every legacy customer-slider image must use explicit empty alt text.'
+)
+assert.equal(
+    /\balt="[^"]+"/.test(legacySlider),
+    false,
+    'Legacy customer slider still contains non-empty repeated alt text.'
+)
+assert.match(
+    legacySlider,
+    /<div aria-hidden="true">\s*<VueSlickCarousel/,
+    'Legacy decorative customer slider must be hidden from assistive technology.'
+)
+
+// eslint-disable-next-line no-console
 console.log('Customer image alt-text source verification passed.')


### PR DESCRIPTION
## What changed

- Adds an explicit decorative mode to the reusable homepage image marquee.
- Marks the homepage customer-photo marquee decorative and renders all customer photos with `alt=""`.
- Keeps the linked artwork marquee and its descriptive alt text unchanged.
- Marks the legacy customer slider decorative and replaces its repeated/nonessential alt text with explicit empty alt attributes on its three generated public routes.
- Adds a source-level regression verifier for both customer slider implementations.

## Why

The homepage has 104 customer photos rendered in two groups for a seamless loop, so one repeated alt phrase appeared 208 times in generated HTML. The legacy Vue Slick component also rendered repeated customer-photo alt text and clones on other public routes. These moving photo strips support adjacent testimonial content and are decorative rather than individually identified content.

## Validation

- `yarn verify:customer-alt`
- ESLint on all affected source files, zero errors or warnings
- Full `yarn generate`
- CMS relation validation: 403 artists, 878 paintings, 155 articles, 107 Art Lovers' Niche articles
- Generated route validation: 2,434 files, including 878 iPad painting routes
- Generated homepage: 208 customer images, all `alt=""`
- Generated homepage artwork strip: 20 images, all descriptive alt text retained
- Three legacy routes: 218 rendered customer images/clones per route, all `alt=""`
- Full generated-site scan: zero occurrences of either repeated customer alt phrase and no numbered placeholder alt text